### PR TITLE
Allow adding environments for private repos

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,6 @@ To use GDC, you need a couple of things:
     - `environment`: Which environment to deploy to (e.g. dev, test or prod)
   - The workflow must create a deployment for the same commit as the release, and update status on success or failure.
   - See [the GDC Deploy workflow](./.github/workflows/deploy.yml) as an example.
-- **KNOWN ISSUE:** Currently, the GitHub Environments API is used to fetch environments. This currently works only for public repos and enterprise private repos.
 
 ## Hosting
 

--- a/src/components/DeploymentDialog.tsx
+++ b/src/components/DeploymentDialog.tsx
@@ -79,7 +79,7 @@ export const DeploymentDialog = () => {
               )}
               renderInput={(params) => (
                 <TextField
-                  label="Extra workflow args"
+                  label="Extra workflow args (press Enter to add)"
                   placeholder="key=value"
                   {...params}
                 />

--- a/src/components/EnvironmentDialog.tsx
+++ b/src/components/EnvironmentDialog.tsx
@@ -61,7 +61,18 @@ export const EnvironmentDialog: FC<{
           <DialogTitle>{title}</DialogTitle>
           <DialogContent>
             {error instanceof Error ? (
-              <Alert severity="error">{error.message}</Alert>
+                <>
+                  <Box mb={2}>
+                    <Alert severity="warning">Could not fetch environments: {error.message}</Alert>
+                  </Box>
+                  <DialogContentText>Enter environment name manually:</DialogContentText>
+                  <TextField
+                      label="Environment name"
+                      value={dialogState.environmentName}
+                      onChange={(e) =>
+                      updateDialogState((state) => (state.environmentName = e.target.value))}
+                  />
+                </>
             ) : (
               <>
                 <DialogContentText>Select environment</DialogContentText>

--- a/src/overmind/index.ts
+++ b/src/overmind/index.ts
@@ -22,4 +22,6 @@ export const useActions = createActionsHook<Context>()
 export const useEffects = createEffectsHook<Context>()
 export const useReaction = createReactionHook<Context>()
 
-export const overmind = createOvermind(config)
+// We set the delimiter to something other than '.', to avoid errors if release strings include dots
+// See e.g. https://github.com/cerebral/overmind/issues/441
+export const overmind = createOvermind(config, { delimiter: '|' })


### PR DESCRIPTION
This allows users with free private repos to add environments manually, when the deployments API doesn't work.
Feel free to fix indentation -- I wasn't sure how to get it right :) Or fix anything else for that matter! 