### PR TITLE
Do not use the supported flag for import and export

### DIFF
--- a/src/components/ManageApplicationsView.tsx
+++ b/src/components/ManageApplicationsView.tsx
@@ -1,5 +1,4 @@
 import { Box, Button } from '@material-ui/core'
-import { supported } from 'browser-fs-access'
 import React from 'react'
 import { useActions } from '../overmind'
 
@@ -16,15 +15,11 @@ export const ManageApplicationsView = () => {
         New application
       </Button>
       <Button
-        onClick={() => exportApplications()}
-        disabled={!supported}
-        title={supported ? '' : 'Not supported in your browser'}>
+        onClick={() => exportApplications()}>
         Export
       </Button>
       <Button
-        onClick={() => importApplications()}
-        disabled={!supported}
-        title={supported ? '' : 'Not supported in your browser'}>
+        onClick={() => importApplications()}>
         Import
       </Button>
     </Box>


### PR DESCRIPTION
The supported flag is only to check if the browser support the new file
system access API. However the library will fall back to the legacy
`<input type="file">` and `<a download/>` if the browser does not support
file system access.

This PR will enable support for Firefox :fox_face: 