### PR TITLE
[codex] Migrate legacy state into active account

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
   "scripts": {
     "analyze": "bun run build && open stats.html",
     "start": "vite",
+    "test": "bun test",
     "preview": "vite preview",
     "build": "tsc && vite build",
     "codegen": "graphql-codegen --config codegen.yml",

--- a/src/api/fetchHooks.ts
+++ b/src/api/fetchHooks.ts
@@ -38,14 +38,22 @@ const repoCacheSchema = z.object({
 })
 
 export const useFetchReleases = () => {
-  const { selectedApplication, settings } = useAppState()
+  const { activeAccountId, selectedApplication, settings, token } = useAppState()
   const refreshIntervalSecs = settings.refreshIntervalSecs
+  const tokenKey = token ? hashString(token) : ''
 
   const repo = selectedApplication?.repo
   const prefix = selectedApplication?.releaseFilter ?? ''
 
   const { data, isLoading, error } = useQuery({
-    queryKey: ['releases', repo?.owner, repo?.name, prefix],
+    queryKey: [
+      'releases',
+      activeAccountId,
+      tokenKey,
+      repo?.owner,
+      repo?.name,
+      prefix,
+    ],
     queryFn: async () => {
       if (!repo) return []
 
@@ -103,12 +111,13 @@ export const useFetchReleases = () => {
 type Workflow = components['schemas']['workflow']
 
 export const useFetchWorkflows = () => {
-  const { token, selectedApplication } = useAppState()
+  const { activeAccountId, token, selectedApplication } = useAppState()
+  const tokenKey = token ? hashString(token) : ''
 
   const repo = selectedApplication?.repo
 
   const { data, isLoading, error } = useQuery({
-    queryKey: ['workflows', repo?.owner, repo?.name],
+    queryKey: ['workflows', activeAccountId, tokenKey, repo?.owner, repo?.name],
     queryFn: async () => {
       if (!token || !repo) return []
 
@@ -134,7 +143,9 @@ export const useFetchWorkflows = () => {
 export const useFetchWorkflowRuns = (): UseQueryResult<
   Record<number, WorkflowRun>
 > => {
-  const { token, selectedApplication, settings } = useAppState()
+  const { activeAccountId, token, selectedApplication, settings } =
+    useAppState()
+  const tokenKey = token ? hashString(token) : ''
   const workflowRuns = settings.workflowRuns
 
   const repo = selectedApplication?.repo
@@ -142,6 +153,8 @@ export const useFetchWorkflowRuns = (): UseQueryResult<
   return useQuery({
     queryKey: [
       'workflow-runs',
+      activeAccountId,
+      tokenKey,
       repo?.owner,
       repo?.name,
       workflowId,
@@ -173,12 +186,19 @@ export const useFetchWorkflowRuns = (): UseQueryResult<
 }
 
 export const useFetchEnvironments = (): UseQueryResult<GitHubEnvironment[]> => {
-  const { token, selectedApplication } = useAppState()
+  const { activeAccountId, token, selectedApplication } = useAppState()
+  const tokenKey = token ? hashString(token) : ''
 
   const repo = selectedApplication?.repo
 
   return useQuery({
-    queryKey: ['environments', repo?.owner, repo?.name],
+    queryKey: [
+      'environments',
+      activeAccountId,
+      tokenKey,
+      repo?.owner,
+      repo?.name,
+    ],
     queryFn: async () => {
       if (!token || !repo) return []
       const { owner, name } = repo
@@ -205,12 +225,12 @@ export const useFetchEnvironments = (): UseQueryResult<GitHubEnvironment[]> => {
 export const useFetchRepos = ({
   autoFetchAll = false,
 }: { autoFetchAll?: boolean } = {}) => {
-  const { token } = useAppState()
+  const { activeAccountId, token } = useAppState()
   const tokenKey = useMemo(() => (token ? hashString(token) : ''), [token])
   const cachedPage = useMemo(() => loadRepoCache(tokenKey), [tokenKey])
 
   const query = useInfiniteQuery({
-    queryKey: ['repos', tokenKey],
+    queryKey: ['repos', activeAccountId, tokenKey],
     enabled: !!token,
     staleTime: REPO_STALE_TIME_MS,
     gcTime: REPO_CACHE_MAX_AGE_MS,

--- a/src/state/schemas.ts
+++ b/src/state/schemas.ts
@@ -108,3 +108,23 @@ export const pendingDeploymentsSchema = z.record(
   z.string(),
   pendingDeploymentSchema
 )
+
+export const accountWorkspaceSchema = z.object({
+  applicationsById: applicationsByIdSchema,
+  selectedApplicationId: z.string(),
+  pendingDeployments: pendingDeploymentsSchema,
+})
+export interface AccountWorkspace
+  extends z.infer<typeof accountWorkspaceSchema> {}
+
+export const accountProfileSchema = z.object({
+  id: z.string(),
+  label: z.string(),
+  token: z.string(),
+  githubLogin: z.string().optional(),
+  githubUserId: z.string().optional(),
+  workspace: accountWorkspaceSchema,
+})
+export interface AccountProfile extends z.infer<typeof accountProfileSchema> {}
+
+export const accountsByIdSchema = z.record(z.string(), accountProfileSchema)

--- a/src/store/accounts.ts
+++ b/src/store/accounts.ts
@@ -97,10 +97,10 @@ export function ensureActiveAccount(state: AccountContainerState) {
   const activeAccount = getActiveAccount(state)
   if (activeAccount) return activeAccount
 
-  const firstAccount = Object.values(state.accountsById)[0]
-  if (firstAccount) {
-    state.activeAccountId = firstAccount.id
-    return firstAccount
+  const firstAccountId = Object.keys(state.accountsById)[0]
+  if (firstAccountId) {
+    state.activeAccountId = firstAccountId
+    return state.accountsById[firstAccountId]
   }
 
   const account = createDefaultAccount()
@@ -132,9 +132,9 @@ export function setActiveAccountApplications(
   applicationsById: Record<string, ApplicationConfig>
 ) {
   const workspace = getActiveWorkspace(state)
-  workspace.applicationsById = applicationsById
+  workspace.applicationsById = { ...applicationsById }
   workspace.selectedApplicationId = normalizeSelectedApplicationId(
-    applicationsById,
+    workspace.applicationsById,
     workspace.selectedApplicationId
   )
 }

--- a/src/store/accounts.ts
+++ b/src/store/accounts.ts
@@ -1,0 +1,163 @@
+import type {
+  AccountProfile,
+  AccountWorkspace,
+  ApplicationConfig,
+  PendingDeployment,
+} from '../state/schemas'
+
+export const DEFAULT_ACCOUNT_ID = 'default-account'
+export const DEFAULT_ACCOUNT_LABEL = 'Default account'
+
+type AccountContainerState = {
+  accountsById: Record<string, AccountProfile>
+  activeAccountId: string
+}
+
+export function createAccountWorkspace({
+  applicationsById = {},
+  selectedApplicationId = '',
+  pendingDeployments = {},
+}: Partial<AccountWorkspace> = {}): AccountWorkspace {
+  return {
+    applicationsById: { ...applicationsById },
+    selectedApplicationId: normalizeSelectedApplicationId(
+      applicationsById,
+      selectedApplicationId
+    ),
+    pendingDeployments: { ...pendingDeployments },
+  }
+}
+
+export function createAccountProfile({
+  id,
+  label = DEFAULT_ACCOUNT_LABEL,
+  token = '',
+  githubLogin,
+  githubUserId,
+  workspace,
+}: {
+  id: string
+  label?: string
+  token?: string
+  githubLogin?: string
+  githubUserId?: string
+  workspace?: Partial<AccountWorkspace>
+}): AccountProfile {
+  return {
+    id,
+    label: label || DEFAULT_ACCOUNT_LABEL,
+    token,
+    githubLogin,
+    githubUserId,
+    workspace: createAccountWorkspace(workspace),
+  }
+}
+
+export function createDefaultAccount({
+  id = DEFAULT_ACCOUNT_ID,
+  token = '',
+  applicationsById = {},
+  selectedApplicationId = '',
+  pendingDeployments = {},
+}: {
+  id?: string
+  token?: string
+  applicationsById?: Record<string, ApplicationConfig>
+  selectedApplicationId?: string
+  pendingDeployments?: Record<string, PendingDeployment>
+} = {}): AccountProfile {
+  return createAccountProfile({
+    id,
+    label: DEFAULT_ACCOUNT_LABEL,
+    token,
+    workspace: {
+      applicationsById,
+      selectedApplicationId,
+      pendingDeployments,
+    },
+  })
+}
+
+export function normalizeSelectedApplicationId(
+  applicationsById: Record<string, ApplicationConfig>,
+  selectedApplicationId?: string
+) {
+  if (selectedApplicationId && applicationsById[selectedApplicationId]) {
+    return selectedApplicationId
+  }
+
+  return Object.keys(applicationsById)[0] ?? ''
+}
+
+export function getActiveAccount(state: AccountContainerState) {
+  return state.accountsById[state.activeAccountId]
+}
+
+export function ensureActiveAccount(state: AccountContainerState) {
+  const activeAccount = getActiveAccount(state)
+  if (activeAccount) return activeAccount
+
+  const firstAccount = Object.values(state.accountsById)[0]
+  if (firstAccount) {
+    state.activeAccountId = firstAccount.id
+    return firstAccount
+  }
+
+  const account = createDefaultAccount()
+  state.accountsById[account.id] = account
+  state.activeAccountId = account.id
+  return account
+}
+
+export function getActiveWorkspace(state: AccountContainerState) {
+  return ensureActiveAccount(state).workspace
+}
+
+export function getSelectedApplication(state: AccountContainerState) {
+  const workspace = getActiveAccount(state)?.workspace
+  if (!workspace) return undefined
+
+  return workspace.applicationsById[workspace.selectedApplicationId]
+}
+
+export function setActiveAccountToken(
+  state: AccountContainerState,
+  token: string
+) {
+  ensureActiveAccount(state).token = token
+}
+
+export function setActiveAccountApplications(
+  state: AccountContainerState,
+  applicationsById: Record<string, ApplicationConfig>
+) {
+  const workspace = getActiveWorkspace(state)
+  workspace.applicationsById = applicationsById
+  workspace.selectedApplicationId = normalizeSelectedApplicationId(
+    applicationsById,
+    workspace.selectedApplicationId
+  )
+}
+
+export function selectActiveApplication(
+  state: AccountContainerState,
+  applicationId: string
+) {
+  const workspace = getActiveWorkspace(state)
+  workspace.selectedApplicationId = normalizeSelectedApplicationId(
+    workspace.applicationsById,
+    applicationId
+  )
+}
+
+export function deleteActiveApplication(
+  state: AccountContainerState,
+  applicationId: string
+) {
+  const workspace = getActiveWorkspace(state)
+  delete workspace.applicationsById[applicationId]
+  workspace.selectedApplicationId = normalizeSelectedApplicationId(
+    workspace.applicationsById,
+    workspace.selectedApplicationId
+  )
+}

--- a/src/store/actions.ts
+++ b/src/store/actions.ts
@@ -12,6 +12,14 @@ import type {
   RepoModel,
 } from '../state/schemas'
 import { showConfirm } from '../utils/dialog'
+import {
+  deleteActiveApplication,
+  getActiveWorkspace,
+  getSelectedApplication,
+  selectActiveApplication,
+  setActiveAccountApplications,
+  setActiveAccountToken,
+} from './accounts'
 import { appState } from './state'
 import { createApplicationDialogState } from './state'
 import type {
@@ -23,7 +31,7 @@ import { downloadJson, restApi, uploadJson } from './services'
 import { getDeploymentId } from './utils'
 
 export const setToken = (token: string) => {
-  appState.token = token
+  setActiveAccountToken(appState, token)
 }
 
 export const showSettings = () => (appState.settingsDialog = {})
@@ -40,8 +48,9 @@ export const setAppSetting = <Key extends keyof AppSettings>(
 export const showNewApplicationModal = () => {
   appState.newApplicationDialog = createApplicationDialogState()
 
-  if (appState.selectedApplication) {
-    appState.newApplicationDialog.repo = clone(appState.selectedApplication.repo)
+  const selectedApplication = getSelectedApplication(appState)
+  if (selectedApplication) {
+    appState.newApplicationDialog.repo = clone(selectedApplication.repo)
   }
 }
 
@@ -82,7 +91,7 @@ export const triggerDeployment = async ({
       owner: repo.owner,
       repo: repo.name,
     })
-    appState.pendingDeployments[deploymentId] = {
+    getActiveWorkspace(appState).pendingDeployments[deploymentId] = {
       createdAt: dayjs().toISOString(),
     }
 
@@ -124,8 +133,9 @@ export const createNewApplication = ({
   releaseFilter: string
 }) => {
   if (!appState.newApplicationDialog) return
+  const workspace = getActiveWorkspace(appState)
   if (
-    Object.values(appState.applicationsById).some(
+    Object.values(workspace.applicationsById).some(
       (app) => app.repo.id === repo.id && app.name === name
     )
   ) {
@@ -134,8 +144,8 @@ export const createNewApplication = ({
     return
   }
   const appConfig = createApplicationConfig(clone(repo), name, releaseFilter)
-  appState.applicationsById[appConfig.id] = appConfig
-  appState.selectedApplicationId = appConfig.id
+  workspace.applicationsById[appConfig.id] = appConfig
+  workspace.selectedApplicationId = appConfig.id
   delete appState.newApplicationDialog
   actions.editDeployment()
 }
@@ -145,7 +155,7 @@ export const cancelNewApplication = () => {
 }
 
 export const selectApplication = (id: string) => {
-  appState.selectedApplicationId = id
+  selectActiveApplication(appState, id)
 }
 
 export const editApplication = () => {
@@ -188,13 +198,14 @@ export const saveApplication = ({
   releaseFilter: string
 }) => {
   if (!appState.editApplicationDialog) return
-  const id = appState.selectedApplicationId
-  const application = appState.applicationsById[id]
+  const workspace = getActiveWorkspace(appState)
+  const id = workspace.selectedApplicationId
+  const application = workspace.applicationsById[id]
   if (!application) return
 
   if (
     some(
-      appState.applicationsById,
+      workspace.applicationsById,
       (app) => app.id !== id && app.repo.id === repo.id && app.name === name
     )
   ) {
@@ -233,7 +244,7 @@ export const deleteApplication = async () => {
       'Are you sure you want to delete ' + appState.selectedApplication.name + '?'
     ))
   ) {
-    delete appState.applicationsById[appState.selectedApplicationId]
+    deleteActiveApplication(appState, appState.selectedApplicationId)
     delete appState.editApplicationDialog
   }
 }
@@ -290,7 +301,7 @@ export const removeEnvironment = async (name: string) => {
 
 export const exportApplications = async () => {
   await downloadJson(
-    snapshot(appState.applicationsById),
+    snapshot(getActiveWorkspace(appState).applicationsById),
     'gdc-applications.json'
   )
 }
@@ -305,10 +316,10 @@ export const importApplications = async () => {
     } catch (e) {
       console.error(e)
     }
-    appState.applicationsById = {
-      ...snapshot(appState.applicationsById),
+    setActiveAccountApplications(appState, {
+      ...snapshot(getActiveWorkspace(appState).applicationsById),
       ...applications,
-    }
+    })
   }
 }
 

--- a/src/store/legacyMigration.ts
+++ b/src/store/legacyMigration.ts
@@ -1,0 +1,59 @@
+import { z } from 'zod'
+import {
+  applicationsByIdSchema,
+  appSettingsSchema,
+  pendingDeploymentsSchema,
+} from '../state/schemas'
+import type { PersistedState } from './persistedState'
+import { createDefaultAccount } from './accounts'
+
+export const MIGRATED_ACCOUNT_ID = 'legacy-account'
+
+const legacyPersistedStateSchema = z.object({
+  token: z.string().optional(),
+  applicationsById: applicationsByIdSchema.optional(),
+  selectedApplicationId: z.string().optional(),
+  pendingDeployments: pendingDeploymentsSchema.optional(),
+  settings: appSettingsSchema.optional(),
+})
+
+type LegacyPersistedState = z.infer<typeof legacyPersistedStateSchema>
+
+export function migrateLegacyPersistedState(
+  data: unknown
+): PersistedState | undefined {
+  const parsed = legacyPersistedStateSchema.safeParse(data)
+  if (!parsed.success) return undefined
+
+  return toAccountPersistedState(parsed.data)
+}
+
+function toAccountPersistedState(state: LegacyPersistedState): PersistedState {
+  const shouldCreateAccount =
+    !!state.token ||
+    Object.keys(state.applicationsById ?? {}).length > 0 ||
+    !!state.selectedApplicationId ||
+    Object.keys(state.pendingDeployments ?? {}).length > 0
+
+  if (!shouldCreateAccount) {
+    return {
+      accountsById: {},
+      activeAccountId: '',
+      settings: state.settings,
+    }
+  }
+
+  const account = createDefaultAccount({
+    id: MIGRATED_ACCOUNT_ID,
+    token: state.token ?? '',
+    applicationsById: state.applicationsById ?? {},
+    selectedApplicationId: state.selectedApplicationId ?? '',
+    pendingDeployments: state.pendingDeployments ?? {},
+  })
+
+  return {
+    accountsById: { [MIGRATED_ACCOUNT_ID]: account },
+    activeAccountId: MIGRATED_ACCOUNT_ID,
+    settings: state.settings,
+  }
+}

--- a/src/store/persistedState.ts
+++ b/src/store/persistedState.ts
@@ -1,10 +1,18 @@
 import { z } from 'zod'
 import {
-  accountsByIdSchema,
+  applicationConfigSchema,
   appSettingsSchema,
+  pendingDeploymentSchema,
 } from '../state/schemas'
-import type { AccountProfile, AppSettings } from '../state/schemas'
-import { createAccountProfile } from './accounts'
+import type {
+  AccountProfile,
+  AccountWorkspace,
+  AppSettings,
+} from '../state/schemas'
+import {
+  createAccountProfile,
+  createAccountWorkspace,
+} from './accounts'
 import { migrateLegacyPersistedState } from './legacyMigration'
 
 export type PersistedState = {
@@ -14,12 +22,26 @@ export type PersistedState = {
 }
 
 const accountPersistedStateSchema = z.object({
-  accountsById: accountsByIdSchema.optional(),
+  accountsById: z.record(z.string(), z.unknown()).optional(),
   activeAccountId: z.string().optional(),
-  settings: appSettingsSchema.optional(),
+  settings: z.unknown().optional(),
 })
 
 type AccountPersistedState = z.infer<typeof accountPersistedStateSchema>
+
+const partialAccountProfileSchema = z.object({
+  label: z.string().optional(),
+  token: z.string().optional(),
+  githubLogin: z.string().optional(),
+  githubUserId: z.string().optional(),
+  workspace: z.unknown().optional(),
+})
+
+const partialAccountWorkspaceSchema = z.object({
+  applicationsById: z.record(z.string(), z.unknown()).optional(),
+  selectedApplicationId: z.string().optional(),
+  pendingDeployments: z.record(z.string(), z.unknown()).optional(),
+})
 
 export function parsePersistedState(data: unknown): PersistedState | undefined {
   if (isAccountPersistedStateLike(data)) {
@@ -35,14 +57,12 @@ function normalizeAccountPersistedState(
   state: AccountPersistedState
 ): PersistedState {
   const accountsById = Object.fromEntries(
-    Object.entries(state.accountsById ?? {}).map(([id, account]) => [
-      id,
-      createAccountProfile({
-        ...account,
-        id,
-        workspace: account.workspace,
-      }),
-    ])
+    Object.entries(state.accountsById ?? {})
+      .map(
+        ([id, account]) =>
+          [id, normalizeAccountProfile(id, account)] as const
+      )
+      .filter((entry): entry is readonly [string, AccountProfile] => !!entry[1])
   )
   const activeAccountId = pickActiveAccountId(
     accountsById,
@@ -52,8 +72,58 @@ function normalizeAccountPersistedState(
   return {
     accountsById,
     activeAccountId,
-    settings: state.settings,
+    settings: parseSettings(state.settings),
   }
+}
+
+function normalizeAccountProfile(id: string, data: unknown) {
+  const parsed = partialAccountProfileSchema.safeParse(data)
+  if (!parsed.success) return undefined
+
+  return createAccountProfile({
+    id,
+    label: parsed.data.label,
+    token: parsed.data.token,
+    githubLogin: parsed.data.githubLogin,
+    githubUserId: parsed.data.githubUserId,
+    workspace: normalizeAccountWorkspace(parsed.data.workspace),
+  })
+}
+
+function normalizeAccountWorkspace(data: unknown): Partial<AccountWorkspace> {
+  const parsed = partialAccountWorkspaceSchema.safeParse(data)
+  if (!parsed.success) return createAccountWorkspace()
+
+  return {
+    applicationsById: parseRecord(
+      parsed.data.applicationsById,
+      applicationConfigSchema
+    ),
+    selectedApplicationId: parsed.data.selectedApplicationId,
+    pendingDeployments: parseRecord(
+      parsed.data.pendingDeployments,
+      pendingDeploymentSchema
+    ),
+  }
+}
+
+function parseRecord<T>(
+  data: Record<string, unknown> | undefined,
+  schema: z.ZodType<T>
+): Record<string, T> | undefined {
+  if (!data) return undefined
+
+  return Object.fromEntries(
+    Object.entries(data).flatMap(([id, value]) => {
+      const parsed = schema.safeParse(value)
+      return parsed.success ? [[id, parsed.data]] : []
+    })
+  )
+}
+
+function parseSettings(data: unknown) {
+  const parsed = appSettingsSchema.safeParse(data)
+  return parsed.success ? parsed.data : undefined
 }
 
 function pickActiveAccountId(

--- a/src/store/persistedState.ts
+++ b/src/store/persistedState.ts
@@ -1,0 +1,76 @@
+import { z } from 'zod'
+import {
+  accountsByIdSchema,
+  appSettingsSchema,
+} from '../state/schemas'
+import type { AccountProfile, AppSettings } from '../state/schemas'
+import { createAccountProfile } from './accounts'
+import { migrateLegacyPersistedState } from './legacyMigration'
+
+export type PersistedState = {
+  accountsById: Record<string, AccountProfile>
+  activeAccountId: string
+  settings?: AppSettings
+}
+
+const accountPersistedStateSchema = z.object({
+  accountsById: accountsByIdSchema.optional(),
+  activeAccountId: z.string().optional(),
+  settings: appSettingsSchema.optional(),
+})
+
+type AccountPersistedState = z.infer<typeof accountPersistedStateSchema>
+
+export function parsePersistedState(data: unknown): PersistedState | undefined {
+  if (isAccountPersistedStateLike(data)) {
+    const parsed = accountPersistedStateSchema.safeParse(data)
+    return parsed.success ? normalizeAccountPersistedState(parsed.data) : undefined
+  }
+
+  // Keep the legacy fallback behind one call so it can be deleted cleanly later.
+  return migrateLegacyPersistedState(data)
+}
+
+function normalizeAccountPersistedState(
+  state: AccountPersistedState
+): PersistedState {
+  const accountsById = Object.fromEntries(
+    Object.entries(state.accountsById ?? {}).map(([id, account]) => [
+      id,
+      createAccountProfile({
+        ...account,
+        id,
+        workspace: account.workspace,
+      }),
+    ])
+  )
+  const activeAccountId = pickActiveAccountId(
+    accountsById,
+    state.activeAccountId
+  )
+
+  return {
+    accountsById,
+    activeAccountId,
+    settings: state.settings,
+  }
+}
+
+function pickActiveAccountId(
+  accountsById: Record<string, AccountProfile>,
+  activeAccountId?: string
+) {
+  if (activeAccountId && accountsById[activeAccountId]) {
+    return activeAccountId
+  }
+
+  return Object.keys(accountsById)[0] ?? ''
+}
+
+function isAccountPersistedStateLike(data: unknown) {
+  return (
+    !!data &&
+    typeof data === 'object' &&
+    ('accountsById' in data || 'activeAccountId' in data)
+  )
+}

--- a/src/store/persistence.ts
+++ b/src/store/persistence.ts
@@ -102,7 +102,7 @@ function filterPendingDeployments(
   pendingDeployments: Record<string, PendingDeployment>
 ) {
   return pickBy(pendingDeployments, (pending) =>
-    dayjs(pending.createdAt).isBefore(dayjs().add(60, 'seconds'))
+    dayjs(pending.createdAt).isAfter(dayjs().subtract(60, 'seconds'))
   )
 }
 

--- a/src/store/persistence.ts
+++ b/src/store/persistence.ts
@@ -19,6 +19,8 @@ export function initializeAppStore() {
   const persistedState = loadPersistedState()
   if (persistedState) {
     applyPersistedState(persistedState)
+    // Rewrite normalized state immediately so legacy migrations are durable.
+    savePersistedState()
   }
 
   syncToken(appState.token)

--- a/src/store/persistence.ts
+++ b/src/store/persistence.ts
@@ -1,27 +1,14 @@
 import dayjs from 'dayjs'
 import { pickBy } from 'lodash-es'
 import { snapshot, subscribe } from 'valtio/vanilla'
-import { z } from 'zod'
-import {
-  applicationsByIdSchema,
-  appSettingsSchema,
-  pendingDeploymentsSchema,
-} from '../state/schemas'
+import type { AccountProfile, PendingDeployment } from '../state/schemas'
 import graphQLApi from '../utils/graphQLApi'
 import { restApi } from './services'
 import { appState } from './state'
+import { parsePersistedState } from './persistedState'
+import type { PersistedState } from './persistedState'
 
 const STORAGE_KEY = 'gdc.v2.state'
-
-const persistedStateSchema = z.object({
-  token: z.string().optional(),
-  applicationsById: applicationsByIdSchema.optional(),
-  selectedApplicationId: z.string().optional(),
-  pendingDeployments: pendingDeploymentsSchema.optional(),
-  settings: appSettingsSchema.optional(),
-})
-
-type PersistedState = z.infer<typeof persistedStateSchema>
 
 let initialized = false
 
@@ -52,20 +39,9 @@ function syncToken(token: string) {
 }
 
 function applyPersistedState(state: PersistedState) {
-  if (state.token !== undefined) {
-    appState.token = state.token
-  }
-  if (state.applicationsById !== undefined) {
-    appState.applicationsById = state.applicationsById
-  }
-  if (state.selectedApplicationId !== undefined) {
-    appState.selectedApplicationId = state.selectedApplicationId
-  }
-  if (state.pendingDeployments !== undefined) {
-    appState.pendingDeployments = filterPendingDeployments(
-      state.pendingDeployments
-    )
-  }
+  appState.accountsById = filterAccountsPendingDeployments(state.accountsById)
+  appState.activeAccountId = state.activeAccountId
+
   if (state.settings !== undefined) {
     appState.settings = state.settings
   }
@@ -79,10 +55,8 @@ function savePersistedState() {
     localStorage.setItem(
       STORAGE_KEY,
       JSON.stringify({
-        token: state.token,
-        applicationsById: state.applicationsById,
-        selectedApplicationId: state.selectedApplicationId,
-        pendingDeployments: state.pendingDeployments,
+        accountsById: state.accountsById,
+        activeAccountId: state.activeAccountId,
         settings: state.settings,
       })
     )
@@ -96,15 +70,34 @@ function loadPersistedState(): PersistedState | undefined {
   if (data === undefined) return undefined
 
   try {
-    return persistedStateSchema.parse(data)
+    return parsePersistedState(data)
   } catch (error) {
     console.error(`Could not load ${STORAGE_KEY}`, error)
     return undefined
   }
 }
 
+function filterAccountsPendingDeployments(
+  accountsById: Record<string, AccountProfile>
+) {
+  return Object.fromEntries(
+    Object.entries(accountsById).map(([id, account]) => [
+      id,
+      {
+        ...account,
+        workspace: {
+          ...account.workspace,
+          pendingDeployments: filterPendingDeployments(
+            account.workspace.pendingDeployments
+          ),
+        },
+      },
+    ])
+  )
+}
+
 function filterPendingDeployments(
-  pendingDeployments: PersistedState['pendingDeployments']
+  pendingDeployments: Record<string, PendingDeployment>
 ) {
   return pickBy(pendingDeployments, (pending) =>
     dayjs(pending.createdAt).isBefore(dayjs().add(60, 'seconds'))

--- a/src/store/state.ts
+++ b/src/store/state.ts
@@ -4,6 +4,7 @@ import { proxy, type Snapshot } from 'valtio/vanilla'
 import { DeploymentState } from '../generated/graphql'
 import { defaultAppSettings } from '../state'
 import type {
+  AccountProfile,
   AppSettings,
   ApplicationConfig,
   DeploySettings,
@@ -53,30 +54,51 @@ export type DeploymentDialogState = DeploySettings
 export type SettingsDialogState = {}
 
 export type AppState = {
-  token: string
-  applicationsById: Record<string, ApplicationConfig>
-  selectedApplicationId: string
-  selectedApplication?: ApplicationConfig
+  accountsById: Record<string, AccountProfile>
+  activeAccountId: string
+  readonly activeAccount?: AccountProfile
+  readonly token: string
+  readonly applicationsById: Record<string, ApplicationConfig>
+  readonly selectedApplicationId: string
+  readonly selectedApplication?: ApplicationConfig
   newApplicationDialog?: ApplicationDialogState
   editApplicationDialog?: ApplicationDialogState
   addEnvironmentDialog?: EnvironmentDialogState
   editEnvironmentDialog?: EnvironmentDialogState
   deploymentDialog?: DeploymentDialogState
   settingsDialog?: SettingsDialogState
-  pendingDeployments: Record<string, PendingDeployment>
+  readonly pendingDeployments: Record<string, PendingDeployment>
   settings: AppSettings
 }
 
-export const appState = proxy<AppState>({
-  token: '',
-  applicationsById: {},
-  selectedApplicationId: '',
-  get selectedApplication() {
-    return this.applicationsById[this.selectedApplicationId]
+export const createInitialAppState = (): AppState => ({
+  accountsById: {},
+  activeAccountId: '',
+  get activeAccount() {
+    return this.accountsById[this.activeAccountId]
   },
-  pendingDeployments: {},
+  get token() {
+    return this.activeAccount?.token ?? ''
+  },
+  get applicationsById() {
+    return this.activeAccount?.workspace.applicationsById ?? {}
+  },
+  get selectedApplicationId() {
+    return this.activeAccount?.workspace.selectedApplicationId ?? ''
+  },
+  get selectedApplication() {
+    const workspace = this.activeAccount?.workspace
+    if (!workspace) return undefined
+
+    return workspace.applicationsById[workspace.selectedApplicationId]
+  },
+  get pendingDeployments() {
+    return this.activeAccount?.workspace.pendingDeployments ?? {}
+  },
   settings: { ...defaultAppSettings },
 })
+
+export const appState = proxy<AppState>(createInitialAppState())
 
 export type AppSnapshot = Snapshot<AppState>
 

--- a/tests/store/accounts.test.ts
+++ b/tests/store/accounts.test.ts
@@ -1,8 +1,10 @@
 import { describe, expect, test } from 'bun:test'
 import {
   DEFAULT_ACCOUNT_ID,
+  getActiveAccount,
   getActiveWorkspace,
   selectActiveApplication,
+  setActiveAccountApplications,
   setActiveAccountToken,
 } from '../../src/store/accounts'
 import { MIGRATED_ACCOUNT_ID } from '../../src/store/legacyMigration'
@@ -102,6 +104,39 @@ describe('persisted account migration', () => {
   test('ignores malformed persisted state without throwing', () => {
     expect(parsePersistedState({ token: 42 })).toBeUndefined()
   })
+
+  test('recovers valid account-shaped state while dropping invalid accounts', () => {
+    const app = appConfig('app-1')
+    const migrated = parsePersistedState({
+      accountsById: {
+        valid: {
+          id: 'stale-id',
+          token: 'ghp_valid',
+          workspace: {
+            applicationsById: { [app.id]: app },
+            selectedApplicationId: app.id,
+            pendingDeployments: {},
+          },
+        },
+        invalid: 42,
+      },
+      activeAccountId: 'invalid',
+      settings: {
+        deployTimeoutSecs: 30,
+        refreshIntervalSecs: 15,
+        workflowRuns: 50,
+      },
+    })
+
+    expect(migrated?.activeAccountId).toBe('valid')
+    expect(Object.keys(migrated?.accountsById ?? {})).toEqual(['valid'])
+    expect(migrated?.accountsById.valid.id).toBe('valid')
+    expect(migrated?.accountsById.valid.token).toBe('ghp_valid')
+    expect(migrated?.accountsById.valid.workspace.selectedApplicationId).toBe(
+      app.id
+    )
+    expect(migrated?.settings?.workflowRuns).toBe(50)
+  })
 })
 
 describe('active account workspace helpers', () => {
@@ -119,5 +154,31 @@ describe('active account workspace helpers', () => {
     expect(state.applicationsById).toEqual({ [app.id]: app })
     expect(state.selectedApplicationId).toBe(app.id)
     expect(state.selectedApplication).toBe(app)
+  })
+
+  test('recovers active account by dictionary key when account id mismatches', () => {
+    const state = createInitialAppState()
+    const workspace = getActiveWorkspace(state)
+    workspace.applicationsById = { 'app-1': appConfig('app-1') }
+
+    state.accountsById[DEFAULT_ACCOUNT_ID].id = 'stale-id'
+    state.activeAccountId = 'missing'
+
+    expect(getActiveAccount(state)).toBeUndefined()
+    expect(getActiveWorkspace(state)).toBe(
+      state.accountsById[DEFAULT_ACCOUNT_ID].workspace
+    )
+    expect(state.activeAccountId).toBe(DEFAULT_ACCOUNT_ID)
+  })
+
+  test('copies application records when replacing active applications', () => {
+    const state = createInitialAppState()
+    const app = appConfig('app-1')
+    const applicationsById = { [app.id]: app }
+
+    setActiveAccountApplications(state, applicationsById)
+    delete applicationsById[app.id]
+
+    expect(state.applicationsById).toEqual({ [app.id]: app })
   })
 })

--- a/tests/store/accounts.test.ts
+++ b/tests/store/accounts.test.ts
@@ -1,0 +1,123 @@
+import { describe, expect, test } from 'bun:test'
+import {
+  DEFAULT_ACCOUNT_ID,
+  getActiveWorkspace,
+  selectActiveApplication,
+  setActiveAccountToken,
+} from '../../src/store/accounts'
+import { MIGRATED_ACCOUNT_ID } from '../../src/store/legacyMigration'
+import { parsePersistedState } from '../../src/store/persistedState'
+import { createInitialAppState } from '../../src/store/state'
+import type { ApplicationConfig } from '../../src/state/schemas'
+
+const appConfig = (id: string, name = id): ApplicationConfig => ({
+  id,
+  name,
+  releaseFilter: '',
+  repo: {
+    id: `repo-${id}`,
+    owner: 'octo',
+    name: `repo-${id}`,
+    defaultBranch: 'main',
+  },
+  deploySettings: {
+    type: 'workflow',
+    environmentKey: 'environment',
+    releaseKey: 'ref',
+    workflowId: 1,
+    ref: 'main',
+    extraArgs: {},
+  },
+  environmentSettingsByName: {},
+})
+
+describe('persisted account migration', () => {
+  test('migrates legacy state into exactly one active account', () => {
+    const app = appConfig('app-1')
+    const migrated = parsePersistedState({
+      token: 'ghp_legacy',
+      applicationsById: { [app.id]: app },
+      selectedApplicationId: app.id,
+      pendingDeployments: {
+        deployment: { createdAt: '2026-04-30T12:00:00.000Z' },
+      },
+      settings: {
+        deployTimeoutSecs: 30,
+        refreshIntervalSecs: 15,
+        workflowRuns: 50,
+      },
+    })
+
+    expect(migrated?.activeAccountId).toBe(MIGRATED_ACCOUNT_ID)
+    expect(Object.keys(migrated?.accountsById ?? {})).toEqual([
+      MIGRATED_ACCOUNT_ID,
+    ])
+    expect(migrated?.accountsById[MIGRATED_ACCOUNT_ID].token).toBe(
+      'ghp_legacy'
+    )
+    expect(
+      migrated?.accountsById[MIGRATED_ACCOUNT_ID].workspace.applicationsById
+    ).toEqual({ [app.id]: app })
+    expect(
+      migrated?.accountsById[MIGRATED_ACCOUNT_ID].workspace
+        .selectedApplicationId
+    ).toBe(app.id)
+    expect(
+      migrated?.accountsById[MIGRATED_ACCOUNT_ID].workspace.pendingDeployments
+        .deployment
+    ).toEqual({ createdAt: '2026-04-30T12:00:00.000Z' })
+    expect(migrated?.settings?.workflowRuns).toBe(50)
+  })
+
+  test('preserves legacy applications even when the token is missing', () => {
+    const app = appConfig('app-1')
+    const migrated = parsePersistedState({
+      applicationsById: { [app.id]: app },
+    })
+
+    expect(migrated?.activeAccountId).toBe(MIGRATED_ACCOUNT_ID)
+    expect(migrated?.accountsById[MIGRATED_ACCOUNT_ID].token).toBe('')
+    expect(
+      migrated?.accountsById[MIGRATED_ACCOUNT_ID].workspace.applicationsById
+    ).toEqual({ [app.id]: app })
+    expect(
+      migrated?.accountsById[MIGRATED_ACCOUNT_ID].workspace
+        .selectedApplicationId
+    ).toBe(app.id)
+  })
+
+  test('creates an empty active account when a legacy token has no applications', () => {
+    const migrated = parsePersistedState({ token: 'ghp_legacy' })
+
+    expect(migrated?.activeAccountId).toBe(MIGRATED_ACCOUNT_ID)
+    expect(
+      migrated?.accountsById[MIGRATED_ACCOUNT_ID].workspace.applicationsById
+    ).toEqual({})
+    expect(
+      migrated?.accountsById[MIGRATED_ACCOUNT_ID].workspace
+        .selectedApplicationId
+    ).toBe('')
+  })
+
+  test('ignores malformed persisted state without throwing', () => {
+    expect(parsePersistedState({ token: 42 })).toBeUndefined()
+  })
+})
+
+describe('active account workspace helpers', () => {
+  test('create one active account and route token and selection through it', () => {
+    const state = createInitialAppState()
+    const app = appConfig('app-1')
+
+    setActiveAccountToken(state, 'ghp_active')
+    const workspace = getActiveWorkspace(state)
+    workspace.applicationsById[app.id] = app
+    selectActiveApplication(state, app.id)
+
+    expect(state.activeAccountId).toBe(DEFAULT_ACCOUNT_ID)
+    expect(state.token).toBe('ghp_active')
+    expect(state.applicationsById).toEqual({ [app.id]: app })
+    expect(state.selectedApplicationId).toBe(app.id)
+    expect(state.selectedApplication).toBe(app)
+  })
+})


### PR DESCRIPTION
## Summary

- Introduce account profile and account workspace state for the app store.
- Migrate legacy single-token persisted state into one active account while preserving applications, selected application, pending deployments, and global settings.
- Route existing application actions through active-account workspace helpers.
- Keep legacy migration isolated in `legacyMigration.ts` so it can be removed cleanly later.
- Scope GitHub-backed query keys by active account and token hash.

## Impact

Existing users should keep their current token and application workspace after upgrading, now represented as a default migrated account. Current UI flows continue to operate through the active account workspace.

Closes #16.

## Validation

- `bun test`
- `bun run build`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for multiple accounts with independent workspaces, applications, and deployments.
  * Improved query caching with account and token-based separation for better data isolation.

* **Chores**
  * Added npm test script for convenient test execution.

* **Tests**
  * Added comprehensive test coverage for account persistence and legacy data migration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->