### PR TITLE
[codex] Add account setup switching and editing

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -42,6 +42,7 @@
         "@types/react": "^19.2.14",
         "@types/react-dom": "^19.2.3",
         "@vitejs/plugin-react": "^6.0.1",
+        "happy-dom": "^15.11.7",
         "json-format": "^1.0.1",
         "json-format-cli": "^1.1.1",
         "rollup-plugin-visualizer": "^7.0.1",
@@ -1039,7 +1040,7 @@
 
     "whatwg-fetch": ["whatwg-fetch@3.6.20", "", {}, "sha512-EqhiFU6daOA8kpjOWTL0olhVOF3i7OrFzSYiGsEMB8GcXS+RrzauAERX65xMeNWVqxA6HXH2m69Z9LaKKdisfg=="],
 
-    "whatwg-mimetype": ["whatwg-mimetype@4.0.0", "", {}, "sha512-QaKxh0eNIi2mE9p2vEdzfagOKHCcj1pJ56EEHGQOVxp8r9/iszLUUV7v89x9O1p/T+NlTM5W7jW6+cz4Fq1YVg=="],
+    "whatwg-mimetype": ["whatwg-mimetype@3.0.0", "", {}, "sha512-nt+N2dzIutVRxARx1nghPKGv1xHikU7HKdfafKkLNLindmPU/ch3U31NOCGGA/dmPcmb1VlofO0vnKAcsm0o/Q=="],
 
     "whatwg-url": ["whatwg-url@5.0.0", "", { "dependencies": { "tr46": "~0.0.3", "webidl-conversions": "^3.0.0" } }, "sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw=="],
 
@@ -1105,8 +1106,6 @@
 
     "graphql-config/cosmiconfig": ["cosmiconfig@8.3.6", "", { "dependencies": { "import-fresh": "^3.3.0", "js-yaml": "^4.1.0", "parse-json": "^5.2.0", "path-type": "^4.0.0" }, "peerDependencies": { "typescript": ">=4.9.5" }, "optionalPeers": ["typescript"] }, "sha512-kcZ6+W5QzcJ3P1Mt+83OUv/oHFqZHIx8DuxG6eZ5RGMERoLqp4BuGjhHLYGK+Kf5XVkQvqBSmAy/nGWN3qDgEA=="],
 
-    "happy-dom/whatwg-mimetype": ["whatwg-mimetype@3.0.0", "", {}, "sha512-nt+N2dzIutVRxARx1nghPKGv1xHikU7HKdfafKkLNLindmPU/ch3U31NOCGGA/dmPcmb1VlofO0vnKAcsm0o/Q=="],
-
     "hoist-non-react-statics/react-is": ["react-is@16.13.1", "", {}, "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ=="],
 
     "import-fresh/resolve-from": ["resolve-from@4.0.0", "", {}, "sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g=="],
@@ -1134,6 +1133,8 @@
     "strip-ansi/ansi-regex": ["ansi-regex@6.2.2", "", {}, "sha512-Bq3SmSpyFHaWjPk8If9yc6svM8c56dB5BAtW4Qbw5jHTwwXXcTLoRMkpDJp6VL0XzlWaCHTXrkFURMYmD0sLqg=="],
 
     "sync-fetch/node-fetch": ["node-fetch@3.3.2", "", { "dependencies": { "data-uri-to-buffer": "^4.0.0", "fetch-blob": "^3.1.4", "formdata-polyfill": "^4.0.10" } }, "sha512-dRB78srN/l6gqWulah9SrxeYnxeddIG30+GOqK/9OlLVyLg3HPnr6SqOWTWOXKRwC2eGYCkZ59NNuSgvSrpgOA=="],
+
+    "sync-fetch/whatwg-mimetype": ["whatwg-mimetype@4.0.0", "", {}, "sha512-QaKxh0eNIi2mE9p2vEdzfagOKHCcj1pJ56EEHGQOVxp8r9/iszLUUV7v89x9O1p/T+NlTM5W7jW6+cz4Fq1YVg=="],
 
     "whatwg-url/webidl-conversions": ["webidl-conversions@3.0.1", "", {}, "sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ=="],
 

--- a/package.json
+++ b/package.json
@@ -53,6 +53,7 @@
     "@types/react": "^19.2.14",
     "@types/react-dom": "^19.2.3",
     "@vitejs/plugin-react": "^6.0.1",
+    "happy-dom": "^15.11.7",
     "json-format": "^1.0.1",
     "json-format-cli": "^1.1.1",
     "rollup-plugin-visualizer": "^7.0.1",

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -3,13 +3,13 @@ import {
   Container,
   Icon,
   IconButton,
-  Link,
   Paper,
-  TextField,
   Typography,
 } from '@mui/material'
 import ModalContainer from 'react-modal-promise'
 import { useFetchRepos } from './api/fetchHooks'
+import { AccountSetupView } from './components/AccountSetupView'
+import { AccountSwitcherView } from './components/AccountSwitcherView'
 import {
   EditApplicationDialog,
   NewApplicationDialog,
@@ -29,8 +29,11 @@ const RepoPreloader = () => {
 }
 
 const App = () => {
-  const { token } = useAppState()
-  const { setToken, showSettings } = useActions()
+  const { accountsById, activeAccountId, token } = useAppState()
+  const { addAccount, editAccount, selectAccount, showSettings } = useActions()
+  const hasAccounts = Object.keys(accountsById).length > 0
+  const hasActiveAccountToken = hasAccounts && !!token
+
   return (
     <Container>
       <Paper sx={{ p: 4, display: 'grid', gap: '1rem' }}>
@@ -46,42 +49,36 @@ const App = () => {
             <Icon>settings</Icon>
           </IconButton>
         </Box>
-        <TextField
-          label="Personal Access Token"
-          value={token}
-          onChange={(e) => setToken(e.target.value)}
-          type="password"
-        />
-        {token ? (
+        {hasAccounts ? (
           <>
-            <RepoPreloader />
-            <ManageApplicationsView />
-            <SelectApplicationView />
-            <EnvironmentsView />
-            <WorkflowInfoView />
-            <ReleasesTableView />
-            <NewApplicationDialog />
-            <EditApplicationDialog />
-            <DeploymentDialog />
+            <AccountSwitcherView
+              accountsById={accountsById}
+              activeAccountId={activeAccountId}
+              addAccount={addAccount}
+              editAccount={editAccount}
+              selectAccount={selectAccount}
+            />
+            {hasActiveAccountToken ? (
+              <>
+                <RepoPreloader />
+                <ManageApplicationsView />
+                <SelectApplicationView />
+                <EnvironmentsView />
+                <WorkflowInfoView />
+                <ReleasesTableView />
+                <NewApplicationDialog />
+                <EditApplicationDialog />
+                <DeploymentDialog />
+              </>
+            ) : (
+              <Typography color="text.secondary">
+                Add a valid personal access token to this account before GitHub
+                data can load.
+              </Typography>
+            )}
           </>
         ) : (
-          <>
-            <Typography>
-              Go to{' '}
-              <Link
-                target="_blank"
-                href="https://github.com/settings/tokens/new"
-              >
-                https://github.com/settings/tokens/new
-              </Link>{' '}
-              to create a new personal access token, and give it the{' '}
-              <code>repo</code> scope.
-            </Typography>
-            <Typography>
-              Your token will be stored in your browser&apos;s local storage,
-              and never leaves your machine.
-            </Typography>
-          </>
+          <AccountSetupView addAccount={addAccount} />
         )}
       </Paper>
       <SettingsDialog />

--- a/src/api/githubIdentity.ts
+++ b/src/api/githubIdentity.ts
@@ -1,0 +1,61 @@
+import { GraphQLClient } from 'graphql-request'
+import { z } from 'zod'
+
+const GITHUB_GRAPHQL_API_URL = 'https://api.github.com/graphql'
+
+const GITHUB_IDENTITY_QUERY = /* GraphQL */ `
+  query githubIdentity {
+    viewer {
+      id
+      login
+    }
+  }
+`
+
+const githubIdentityResponseSchema = z.object({
+  viewer: z.object({
+    id: z.string().min(1),
+    login: z.string().min(1),
+  }),
+})
+
+export type GitHubIdentity = {
+  id: string
+  login: string
+}
+
+export type GitHubIdentityResolver = (token: string) => Promise<GitHubIdentity>
+
+export class GitHubIdentityError extends Error {
+  constructor() {
+    super('Could not validate the personal access token.')
+    this.name = 'GitHubIdentityError'
+  }
+}
+
+export function createGitHubIdentityResolver(
+  requestIdentity: (token: string) => Promise<unknown>
+): GitHubIdentityResolver {
+  return async (token) => {
+    try {
+      const result = githubIdentityResponseSchema.parse(
+        await requestIdentity(token)
+      )
+      return result.viewer
+    } catch {
+      throw new GitHubIdentityError()
+    }
+  }
+}
+
+export const resolveGitHubIdentity = createGitHubIdentityResolver(
+  async (token) => {
+    const client = new GraphQLClient(GITHUB_GRAPHQL_API_URL, {
+      headers: {
+        Authorization: `Bearer ${token}`,
+      },
+    })
+
+    return client.request(GITHUB_IDENTITY_QUERY)
+  }
+)

--- a/src/components/AccountEditView.tsx
+++ b/src/components/AccountEditView.tsx
@@ -1,0 +1,91 @@
+import { Alert, Box, Button, Icon, TextField, Typography } from '@mui/material'
+import { useState } from 'react'
+import type { FormEvent } from 'react'
+import type { AccountProfile } from '../state/schemas'
+import type { EditAccountInput } from '../store/actions'
+
+type AccountEditViewProps = {
+  account: AccountProfile
+  editAccount: (input: EditAccountInput) => Promise<unknown>
+  onSaved?: () => void
+}
+
+export function AccountEditView({
+  account,
+  editAccount,
+  onSaved,
+}: AccountEditViewProps) {
+  const [label, setLabel] = useState(account.label)
+  const [token, setToken] = useState('')
+  const [error, setError] = useState<string>()
+  const [isSaving, setIsSaving] = useState(false)
+
+  const canSave = !!label.trim() && !isSaving
+
+  const handleSubmit = async (event: FormEvent<HTMLFormElement>) => {
+    event.preventDefault()
+    setError(undefined)
+    setIsSaving(true)
+
+    try {
+      await editAccount({
+        accountId: account.id,
+        label,
+        token,
+      })
+      onSaved?.()
+    } catch (error) {
+      setError(
+        error instanceof Error
+          ? error.message
+          : 'Could not save that account. Check the token and try again.'
+      )
+    } finally {
+      setIsSaving(false)
+    }
+  }
+
+  return (
+    <Box
+      component="form"
+      onSubmit={handleSubmit}
+      sx={{ display: 'grid', gap: 2, maxWidth: 560 }}
+    >
+      <Box sx={{ display: 'grid', gap: 0.75 }}>
+        <Typography variant="h5" component="h2">
+          Edit account
+        </Typography>
+        <Typography color="text.secondary">
+          Personal access tokens are stored in your browser&apos;s local
+          storage.
+        </Typography>
+      </Box>
+      {error ? <Alert severity="error">{error}</Alert> : null}
+      <TextField
+        label="Account label"
+        value={label}
+        onChange={(event) => setLabel(event.target.value)}
+        autoComplete="off"
+        required
+      />
+      <TextField
+        label="Replace personal access token"
+        value={token}
+        onChange={(event) => setToken(event.target.value)}
+        type="password"
+        autoComplete="off"
+        helperText="Leave blank to keep the current token. Replacements must belong to the same GitHub user."
+      />
+      <Box sx={{ display: 'flex', justifyContent: 'flex-end' }}>
+        <Button
+          type="submit"
+          variant="contained"
+          disabled={!canSave}
+          startIcon={<Icon>save</Icon>}
+        >
+          {isSaving ? 'Saving account...' : 'Save account'}
+        </Button>
+      </Box>
+    </Box>
+  )
+}

--- a/src/components/AccountSetupView.tsx
+++ b/src/components/AccountSetupView.tsx
@@ -1,0 +1,109 @@
+import {
+  Alert,
+  Box,
+  Button,
+  Icon,
+  Link,
+  TextField,
+  Typography,
+} from '@mui/material'
+import { useState } from 'react'
+import type { FormEvent } from 'react'
+import type { AddAccountInput } from '../store/actions'
+
+type AccountSetupViewProps = {
+  addAccount: (input: AddAccountInput) => Promise<unknown>
+  title?: string
+  description?: string
+  submitLabel?: string
+  onAdded?: () => void
+}
+
+export function AccountSetupView({
+  addAccount,
+  title = 'Add your GitHub account',
+  description = "Personal access tokens are stored in your browser's local storage.",
+  submitLabel = 'Add account',
+  onAdded,
+}: AccountSetupViewProps) {
+  const [label, setLabel] = useState('')
+  const [token, setToken] = useState('')
+  const [error, setError] = useState<string>()
+  const [isAdding, setIsAdding] = useState(false)
+
+  const canAdd = !!label.trim() && !!token.trim() && !isAdding
+
+  const handleSubmit = async (event: FormEvent<HTMLFormElement>) => {
+    event.preventDefault()
+    setError(undefined)
+    setIsAdding(true)
+
+    try {
+      await addAccount({ label, token })
+      onAdded?.()
+    } catch (error) {
+      setError(
+        error instanceof Error
+          ? error.message
+          : 'Could not add that account. Check the token and try again.'
+      )
+    } finally {
+      setIsAdding(false)
+    }
+  }
+
+  return (
+    <Box
+      component="form"
+      onSubmit={handleSubmit}
+      sx={{
+        display: 'grid',
+        gap: 2,
+        maxWidth: 560,
+      }}
+    >
+      <Box sx={{ display: 'grid', gap: 0.75 }}>
+        <Typography variant="h5" component="h2">
+          {title}
+        </Typography>
+        <Typography color="text.secondary">
+          {description}
+        </Typography>
+      </Box>
+      {error ? <Alert severity="error">{error}</Alert> : null}
+      <TextField
+        label="Account label"
+        value={label}
+        onChange={(event) => setLabel(event.target.value)}
+        autoComplete="off"
+        required
+      />
+      <TextField
+        label="Personal access token"
+        value={token}
+        onChange={(event) => setToken(event.target.value)}
+        type="password"
+        autoComplete="off"
+        required
+        helperText={
+          <>
+            <Link target="_blank" href="https://github.com/settings/tokens/new">
+              Create a token
+            </Link>{' '}
+            with the <code>repo</code> scope.
+          </>
+        }
+      />
+      <Box sx={{ display: 'flex', justifyContent: 'flex-end' }}>
+        <Button
+          type="submit"
+          variant="contained"
+          disabled={!canAdd}
+          startIcon={<Icon>person_add</Icon>}
+        >
+          {isAdding ? 'Adding account...' : submitLabel}
+        </Button>
+      </Box>
+    </Box>
+  )
+}

--- a/src/components/AccountSwitcherView.tsx
+++ b/src/components/AccountSwitcherView.tsx
@@ -1,0 +1,131 @@
+import {
+  Box,
+  Button,
+  Dialog,
+  DialogContent,
+  DialogTitle,
+  FormControl,
+  Icon,
+  InputLabel,
+  Select,
+  Typography,
+} from '@mui/material'
+import { useState } from 'react'
+import type { AccountProfile } from '../state/schemas'
+import type { AddAccountInput, EditAccountInput } from '../store/actions'
+import { AccountEditView } from './AccountEditView'
+import { AccountSetupView } from './AccountSetupView'
+
+type AccountSwitcherViewProps = {
+  accountsById: Record<string, AccountProfile>
+  activeAccountId: string
+  addAccount: (input: AddAccountInput) => Promise<unknown>
+  editAccount: (input: EditAccountInput) => Promise<unknown>
+  selectAccount: (accountId: string) => void
+}
+
+export function AccountSwitcherView({
+  accountsById,
+  activeAccountId,
+  addAccount,
+  editAccount,
+  selectAccount,
+}: AccountSwitcherViewProps) {
+  const [addDialogOpen, setAddDialogOpen] = useState(false)
+  const [editDialogOpen, setEditDialogOpen] = useState(false)
+  const accounts = Object.values(accountsById)
+  const activeAccount = accountsById[activeAccountId]
+
+  return (
+    <Box sx={{ display: 'grid', gap: 1.5 }}>
+      <Box
+        sx={{
+          display: 'flex',
+          flexWrap: 'wrap',
+          alignItems: 'center',
+          gap: 1.5,
+        }}
+      >
+        <FormControl size="small" sx={{ minWidth: 280 }}>
+          <InputLabel htmlFor="active-account-select">
+            Active account
+          </InputLabel>
+          <Select
+            native
+            label="Active account"
+            value={activeAccountId}
+            inputProps={{
+              id: 'active-account-select',
+            }}
+            onChange={(event) => selectAccount(String(event.target.value))}
+          >
+            {accounts.map((account) => (
+              <option key={account.id} value={account.id}>
+                {formatAccountOption(account)}
+              </option>
+            ))}
+          </Select>
+        </FormControl>
+        <Button
+          variant="outlined"
+          startIcon={<Icon>person_add</Icon>}
+          onClick={() => setAddDialogOpen(true)}
+        >
+          Add account
+        </Button>
+        <Button
+          variant="outlined"
+          startIcon={<Icon>edit</Icon>}
+          onClick={() => setEditDialogOpen(true)}
+          disabled={!activeAccount}
+        >
+          Edit account
+        </Button>
+      </Box>
+      {activeAccount?.githubLogin ? (
+        <Typography color="text.secondary">
+          Signed in as @{activeAccount.githubLogin}
+        </Typography>
+      ) : null}
+      <Dialog
+        open={addDialogOpen}
+        fullWidth
+        maxWidth="sm"
+        onClose={() => setAddDialogOpen(false)}
+      >
+        <DialogTitle>Add account</DialogTitle>
+        <DialogContent>
+          <AccountSetupView
+            addAccount={addAccount}
+            title="Add another GitHub account"
+            submitLabel="Add account"
+            onAdded={() => setAddDialogOpen(false)}
+          />
+        </DialogContent>
+      </Dialog>
+      <Dialog
+        open={editDialogOpen}
+        fullWidth
+        maxWidth="sm"
+        onClose={() => setEditDialogOpen(false)}
+      >
+        <DialogTitle>Edit account</DialogTitle>
+        <DialogContent>
+          {activeAccount ? (
+            <AccountEditView
+              account={activeAccount}
+              editAccount={editAccount}
+              onSaved={() => setEditDialogOpen(false)}
+            />
+          ) : null}
+        </DialogContent>
+      </Dialog>
+    </Box>
+  )
+}
+
+function formatAccountOption(account: AccountProfile) {
+  return account.githubLogin
+    ? `${account.label} (@${account.githubLogin})`
+    : account.label
+}

--- a/src/store/accounts.ts
+++ b/src/store/accounts.ts
@@ -1,3 +1,4 @@
+import { v4 as uuid } from 'uuid'
 import type {
   AccountProfile,
   AccountWorkspace,
@@ -78,6 +79,34 @@ export function createDefaultAccount({
   })
 }
 
+export function addAccountProfile(
+  state: AccountContainerState,
+  {
+    id = uuid(),
+    label,
+    token,
+    githubLogin,
+    githubUserId,
+  }: {
+    id?: string
+    label: string
+    token: string
+    githubLogin: string
+    githubUserId: string
+  }
+) {
+  const account = createAccountProfile({
+    id,
+    label,
+    token,
+    githubLogin,
+    githubUserId,
+  })
+  state.accountsById[account.id] = account
+  state.activeAccountId = account.id
+  return account
+}
+
 export function normalizeSelectedApplicationId(
   applicationsById: Record<string, ApplicationConfig>,
   selectedApplicationId?: string
@@ -91,6 +120,39 @@ export function normalizeSelectedApplicationId(
 
 export function getActiveAccount(state: AccountContainerState) {
   return state.accountsById[state.activeAccountId]
+}
+
+export function setActiveAccount(
+  state: AccountContainerState,
+  accountId: string
+) {
+  if (!state.accountsById[accountId]) return false
+
+  state.activeAccountId = accountId
+  return true
+}
+
+export function updateAccountProfile(
+  state: AccountContainerState,
+  accountId: string,
+  update: Pick<AccountProfile, 'label'> &
+    Partial<Pick<AccountProfile, 'token' | 'githubLogin' | 'githubUserId'>>
+) {
+  const account = state.accountsById[accountId]
+  if (!account) return undefined
+
+  account.label = update.label
+  if (update.token !== undefined) {
+    account.token = update.token
+  }
+  if (update.githubLogin !== undefined) {
+    account.githubLogin = update.githubLogin
+  }
+  if (update.githubUserId !== undefined) {
+    account.githubUserId = update.githubUserId
+  }
+
+  return account
 }
 
 export function ensureActiveAccount(state: AccountContainerState) {

--- a/src/store/actions.ts
+++ b/src/store/actions.ts
@@ -11,18 +11,26 @@ import type {
   EnvironmentSettings,
   RepoModel,
 } from '../state/schemas'
+import {
+  resolveGitHubIdentity,
+  type GitHubIdentityResolver,
+} from '../api/githubIdentity'
 import { showConfirm } from '../utils/dialog'
 import {
+  addAccountProfile,
   deleteActiveApplication,
   getActiveWorkspace,
   getSelectedApplication,
   selectActiveApplication,
+  setActiveAccount,
   setActiveAccountApplications,
   setActiveAccountToken,
+  updateAccountProfile,
 } from './accounts'
 import { appState } from './state'
 import { createApplicationDialogState } from './state'
 import type {
+  AppState,
   ApplicationDialogState,
   DeploymentDialogState,
   EnvironmentDialogState,
@@ -32,6 +40,106 @@ import { getDeploymentId } from './utils'
 
 export const setToken = (token: string) => {
   setActiveAccountToken(appState, token)
+}
+
+export type AddAccountInput = {
+  label: string
+  token: string
+}
+
+export async function addAccountToState(
+  state: AppState,
+  { label, token }: AddAccountInput,
+  resolveIdentity: GitHubIdentityResolver = resolveGitHubIdentity
+) {
+  const normalizedLabel = label.trim()
+  const normalizedToken = token.trim()
+
+  if (!normalizedLabel) {
+    throw new Error('Enter an account label.')
+  }
+
+  if (!normalizedToken) {
+    throw new Error('Enter a personal access token.')
+  }
+
+  let identity
+  try {
+    identity = await resolveIdentity(normalizedToken)
+  } catch {
+    throw new Error(
+      'Could not validate that personal access token. Check the token and try again.'
+    )
+  }
+
+  return addAccountProfile(state, {
+    label: normalizedLabel,
+    token: normalizedToken,
+    githubLogin: identity.login,
+    githubUserId: identity.id,
+  })
+}
+
+export const addAccount = (input: AddAccountInput) =>
+  addAccountToState(appState, input)
+
+export type EditAccountInput = {
+  accountId: string
+  label: string
+  token?: string
+}
+
+export async function editAccountInState(
+  state: AppState,
+  { accountId, label, token = '' }: EditAccountInput,
+  resolveIdentity: GitHubIdentityResolver = resolveGitHubIdentity
+) {
+  const account = state.accountsById[accountId]
+  if (!account) {
+    throw new Error('Account not found.')
+  }
+
+  const normalizedLabel = label.trim()
+  const normalizedToken = token.trim()
+
+  if (!normalizedLabel) {
+    throw new Error('Enter an account label.')
+  }
+
+  if (!normalizedToken) {
+    return updateAccountProfile(state, accountId, {
+      label: normalizedLabel,
+    })
+  }
+
+  let identity
+  try {
+    identity = await resolveIdentity(normalizedToken)
+  } catch {
+    throw new Error(
+      'Could not validate that personal access token. Check the token and try again.'
+    )
+  }
+
+  if (account.githubUserId && identity.id !== account.githubUserId) {
+    throw new Error(
+      `That token belongs to @${identity.login}, not @${account.githubLogin ?? account.label}. Add it as a new account instead.`
+    )
+  }
+
+  return updateAccountProfile(state, accountId, {
+    label: normalizedLabel,
+    token: normalizedToken,
+    githubLogin: identity.login,
+    githubUserId: identity.id,
+  })
+}
+
+export const editAccount = (input: EditAccountInput) =>
+  editAccountInState(appState, input)
+
+export const selectAccount = (accountId: string) => {
+  setActiveAccount(appState, accountId)
 }
 
 export const showSettings = () => (appState.settingsDialog = {})
@@ -324,6 +432,7 @@ export const importApplications = async () => {
 }
 
 export const actions = {
+  addAccount,
   addEnvironment,
   cancelAddEnvironment,
   cancelEditApplication,
@@ -332,6 +441,7 @@ export const actions = {
   createNewApplication,
   deleteApplication,
   editApplication,
+  editAccount,
   editDeployment,
   exportApplications,
   hideSettings,
@@ -339,6 +449,7 @@ export const actions = {
   removeEnvironment,
   saveApplication,
   saveDeployment,
+  selectAccount,
   selectApplication,
   setAppSetting,
   setToken,

--- a/src/theme.ts
+++ b/src/theme.ts
@@ -11,6 +11,13 @@ export const theme = createTheme({
     primary: green,
     secondary: purple,
   },
+  typography: {
+    h1: {
+      fontSize: '2rem',
+      fontWeight: 500,
+      lineHeight: 1.2,
+    },
+  },
   components: {
     MuiDialogContent: {
       styleOverrides: {

--- a/tests/App.test.tsx
+++ b/tests/App.test.tsx
@@ -1,0 +1,27 @@
+import './setupDom'
+import { afterEach, describe, expect, test } from 'bun:test'
+import { cleanup, render } from '@testing-library/react'
+import App from '../src/App'
+import { appState } from '../src/store'
+
+afterEach(() => {
+  cleanup()
+  appState.accountsById = {}
+  appState.activeAccountId = ''
+})
+
+describe('App account setup state', () => {
+  test('shows first-account setup when no accounts exist', () => {
+    appState.accountsById = {}
+    appState.activeAccountId = ''
+
+    const { getByLabelText, getByText } = render(<App />)
+    const tokenInput = getByLabelText(
+      /personal access token/i
+    ) as HTMLInputElement
+
+    expect(getByText('Add your GitHub account')).toBeTruthy()
+    expect(getByLabelText(/account label/i)).toBeTruthy()
+    expect(tokenInput.type).toBe('password')
+  })
+})

--- a/tests/api/githubIdentity.test.ts
+++ b/tests/api/githubIdentity.test.ts
@@ -1,0 +1,46 @@
+import { describe, expect, test } from 'bun:test'
+import {
+  GitHubIdentityError,
+  createGitHubIdentityResolver,
+} from '../../src/api/githubIdentity'
+
+describe('GitHub identity resolver', () => {
+  test('resolves viewer id and login through the supplied request function', async () => {
+    const requestedTokens: string[] = []
+    const resolveIdentity = createGitHubIdentityResolver(async (token) => {
+      requestedTokens.push(token)
+      return {
+        viewer: {
+          id: 'U_123',
+          login: 'octocat',
+        },
+      }
+    })
+
+    const identity = await resolveIdentity('ghp_valid')
+
+    expect(requestedTokens).toEqual(['ghp_valid'])
+    expect(identity).toEqual({
+      id: 'U_123',
+      login: 'octocat',
+    })
+  })
+
+  test('rejects malformed identity responses', async () => {
+    const resolveIdentity = createGitHubIdentityResolver(async () => ({
+      viewer: {
+        id: '',
+        login: '',
+      },
+    }))
+
+    let error: unknown
+    try {
+      await resolveIdentity('ghp_invalid')
+    } catch (caught) {
+      error = caught
+    }
+
+    expect(error).toBeInstanceOf(GitHubIdentityError)
+  })
+})

--- a/tests/components/AccountSetupView.test.tsx
+++ b/tests/components/AccountSetupView.test.tsx
@@ -1,0 +1,72 @@
+import '../setupDom'
+import { afterEach, describe, expect, test } from 'bun:test'
+import { cleanup, render, waitFor } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { AccountSetupView } from '../../src/components/AccountSetupView'
+import type { AddAccountInput } from '../../src/store/actions'
+
+afterEach(() => {
+  cleanup()
+})
+
+describe('AccountSetupView', () => {
+  test('collects a label and password PAT before adding the account', async () => {
+    const submitted: AddAccountInput[] = []
+    const user = userEvent.setup()
+
+    const { getByLabelText, getByRole, getByText } = render(
+      <AccountSetupView
+        addAccount={async (input) => {
+          submitted.push(input)
+        }}
+      />
+    )
+
+    const tokenInput = getByLabelText(
+      /personal access token/i
+    ) as HTMLInputElement
+    expect(tokenInput.type).toBe('password')
+    expect(getByText(/stored in your browser's local storage/i)).toBeTruthy()
+
+    await user.type(getByLabelText(/account label/i), 'Work')
+    await user.type(tokenInput, 'ghp_valid')
+    await user.click(getByRole('button', { name: /add account/i }))
+
+    await waitFor(() => {
+      expect(submitted).toEqual([
+        {
+          label: 'Work',
+          token: 'ghp_valid',
+        },
+      ])
+    })
+  })
+
+  test('shows add-account errors without clearing the entered PAT', async () => {
+    const user = userEvent.setup()
+
+    const { getByLabelText, getByRole } = render(
+      <AccountSetupView
+        addAccount={async () => {
+          throw new Error(
+            'Could not validate that personal access token. Check the token and try again.'
+          )
+        }}
+      />
+    )
+
+    const tokenInput = getByLabelText(
+      /personal access token/i
+    ) as HTMLInputElement
+    await user.type(getByLabelText(/account label/i), 'Work')
+    await user.type(tokenInput, 'ghp_invalid')
+    await user.click(getByRole('button', { name: /add account/i }))
+
+    await waitFor(() => {
+      expect(getByRole('alert').textContent).toContain(
+        'Could not validate that personal access token'
+      )
+    })
+    expect(tokenInput.value).toBe('ghp_invalid')
+  })
+})

--- a/tests/components/AccountSwitcherView.test.tsx
+++ b/tests/components/AccountSwitcherView.test.tsx
@@ -1,0 +1,143 @@
+import '../setupDom'
+import { afterEach, describe, expect, test } from 'bun:test'
+import { cleanup, render, waitFor, within } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { createAccountProfile } from '../../src/store/accounts'
+import { AccountSwitcherView } from '../../src/components/AccountSwitcherView'
+import type { AddAccountInput } from '../../src/store/actions'
+
+afterEach(() => {
+  cleanup()
+})
+
+describe('AccountSwitcherView', () => {
+  test('shows account labels and login metadata while switching accounts', async () => {
+    const selectedAccountIds: string[] = []
+    const user = userEvent.setup()
+
+    const { getByLabelText, getByText } = render(
+      <AccountSwitcherView
+        accountsById={{
+          work: createAccountProfile({
+            id: 'work',
+            label: 'Work',
+            token: 'ghp_work',
+            githubLogin: 'work-octocat',
+            githubUserId: 'U_work',
+          }),
+          personal: createAccountProfile({
+            id: 'personal',
+            label: 'Personal',
+            token: 'ghp_personal',
+            githubLogin: 'octocat',
+            githubUserId: 'U_personal',
+          }),
+        }}
+        activeAccountId="work"
+        addAccount={async () => {}}
+        editAccount={async () => {}}
+        selectAccount={(accountId) => selectedAccountIds.push(accountId)}
+      />
+    )
+
+    expect(getByText('Signed in as @work-octocat')).toBeTruthy()
+
+    await user.selectOptions(getByLabelText(/active account/i), 'personal')
+
+    expect(selectedAccountIds).toEqual(['personal'])
+  })
+
+  test('adds another account from the dialog', async () => {
+    const submitted: AddAccountInput[] = []
+    const user = userEvent.setup()
+
+    const { getByRole, getByLabelText } = render(
+      <AccountSwitcherView
+        accountsById={{
+          work: createAccountProfile({
+            id: 'work',
+            label: 'Work',
+            token: 'ghp_work',
+            githubLogin: 'work-octocat',
+            githubUserId: 'U_work',
+          }),
+        }}
+        activeAccountId="work"
+        addAccount={async (input) => {
+          submitted.push(input)
+        }}
+        editAccount={async () => {}}
+        selectAccount={() => {}}
+      />
+    )
+
+    await user.click(getByRole('button', { name: /add account/i }))
+    const dialog = getByRole('dialog')
+
+    await user.type(within(dialog).getByLabelText(/account label/i), 'Client')
+    await user.type(getByLabelText(/personal access token/i), 'ghp_client')
+    await user.click(within(dialog).getByRole('button', { name: /add account/i }))
+
+    await waitFor(() => {
+      expect(submitted).toEqual([
+        {
+          label: 'Client',
+          token: 'ghp_client',
+        },
+      ])
+    })
+  })
+
+  test('edits the active account from the dialog', async () => {
+    const submitted: unknown[] = []
+    const user = userEvent.setup()
+
+    const { getByRole } = render(
+      <AccountSwitcherView
+        accountsById={{
+          work: createAccountProfile({
+            id: 'work',
+            label: 'Work',
+            token: 'ghp_work',
+            githubLogin: 'work-octocat',
+            githubUserId: 'U_work',
+          }),
+        }}
+        activeAccountId="work"
+        addAccount={async () => {}}
+        editAccount={async (input) => {
+          submitted.push(input)
+        }}
+        selectAccount={() => {}}
+      />
+    )
+
+    await user.click(getByRole('button', { name: /edit account/i }))
+    const dialog = getByRole('dialog')
+    const labelInput = within(dialog).getByLabelText(
+      /account label/i
+    ) as HTMLInputElement
+    const tokenInput = within(dialog).getByLabelText(
+      /replace personal access token/i
+    ) as HTMLInputElement
+
+    expect(labelInput.value).toBe('Work')
+    expect(tokenInput.type).toBe('password')
+
+    await user.clear(labelInput)
+    await user.type(labelInput, 'Work deploys')
+    await user.click(
+      within(dialog).getByRole('button', { name: /save account/i })
+    )
+
+    await waitFor(() => {
+      expect(submitted).toEqual([
+        {
+          accountId: 'work',
+          label: 'Work deploys',
+          token: '',
+        },
+      ])
+    })
+  })
+})

--- a/tests/setupDom.ts
+++ b/tests/setupDom.ts
@@ -1,0 +1,55 @@
+import { Window } from 'happy-dom'
+
+const window = new Window({
+  url: 'http://localhost/',
+})
+
+for (const key of [
+  'window',
+  'document',
+  'navigator',
+  'Node',
+  'Text',
+  'Element',
+  'HTMLElement',
+  'HTMLButtonElement',
+  'HTMLFormElement',
+  'HTMLInputElement',
+  'SVGElement',
+  'DocumentFragment',
+  'Event',
+  'MouseEvent',
+  'KeyboardEvent',
+  'FocusEvent',
+  'InputEvent',
+  'MutationObserver',
+  'ResizeObserver',
+  'localStorage',
+] as const) {
+  Object.defineProperty(globalThis, key, {
+    value: window[key],
+    configurable: true,
+    writable: true,
+  })
+}
+
+Object.defineProperty(globalThis, 'getComputedStyle', {
+  value: window.getComputedStyle.bind(window),
+  configurable: true,
+  writable: true,
+})
+
+Object.defineProperty(globalThis, 'requestAnimationFrame', {
+  value: (callback: FrameRequestCallback) =>
+    window.setTimeout(() => callback(Date.now()), 0),
+  configurable: true,
+  writable: true,
+})
+
+Object.defineProperty(globalThis, 'cancelAnimationFrame', {
+  value: (handle: number) => window.clearTimeout(handle),
+  configurable: true,
+  writable: true,
+})
+
+window.factoryStack = window.factoryStack ?? {}

--- a/tests/store/accounts.test.ts
+++ b/tests/store/accounts.test.ts
@@ -1,12 +1,16 @@
 import { describe, expect, test } from 'bun:test'
 import {
   DEFAULT_ACCOUNT_ID,
+  createAccountProfile,
   getActiveAccount,
   getActiveWorkspace,
   selectActiveApplication,
+  setActiveAccount,
   setActiveAccountApplications,
   setActiveAccountToken,
 } from '../../src/store/accounts'
+import { addAccountToState } from '../../src/store/actions'
+import { editAccountInState } from '../../src/store/actions'
 import { MIGRATED_ACCOUNT_ID } from '../../src/store/legacyMigration'
 import { parsePersistedState } from '../../src/store/persistedState'
 import { createInitialAppState } from '../../src/store/state'
@@ -180,5 +184,292 @@ describe('active account workspace helpers', () => {
     delete applicationsById[app.id]
 
     expect(state.applicationsById).toEqual({ [app.id]: app })
+  })
+})
+
+describe('add account action', () => {
+  test('validates, saves, and activates a new account', async () => {
+    const state = createInitialAppState()
+    const requestedTokens: string[] = []
+
+    const account = await addAccountToState(
+      state,
+      {
+        label: ' Work ',
+        token: ' ghp_valid ',
+      },
+      async (token) => {
+        requestedTokens.push(token)
+        return {
+          id: 'U_123',
+          login: 'octocat',
+        }
+      }
+    )
+
+    expect(requestedTokens).toEqual(['ghp_valid'])
+    expect(state.activeAccountId).toBe(account.id)
+    expect(Object.keys(state.accountsById)).toEqual([account.id])
+    expect(account.label).toBe('Work')
+    expect(account.token).toBe('ghp_valid')
+    expect(account.githubLogin).toBe('octocat')
+    expect(account.githubUserId).toBe('U_123')
+  })
+
+  test('rejects invalid PATs without saving an account', async () => {
+    const state = createInitialAppState()
+
+    let error: unknown
+    try {
+      await addAccountToState(
+        state,
+        {
+          label: 'Work',
+          token: 'ghp_invalid',
+        },
+        async () => {
+          throw new Error('Bad credentials')
+        }
+      )
+    } catch (caught) {
+      error = caught
+    }
+
+    expect(error).toBeInstanceOf(Error)
+    expect((error as Error).message).toContain(
+      'Could not validate that personal access token'
+    )
+    expect(state.accountsById).toEqual({})
+    expect(state.activeAccountId).toBe('')
+  })
+
+  test('adds a second account without changing the existing workspace', async () => {
+    const state = createInitialAppState()
+    const workApp = appConfig('work-app')
+    state.accountsById.work = createAccountProfile({
+      id: 'work',
+      label: 'Work',
+      token: 'ghp_work',
+      workspace: {
+        applicationsById: { [workApp.id]: workApp },
+        selectedApplicationId: workApp.id,
+      },
+    })
+    state.activeAccountId = 'work'
+
+    const account = await addAccountToState(
+      state,
+      {
+        label: 'Personal',
+        token: 'ghp_personal',
+      },
+      async () => ({
+        id: 'U_personal',
+        login: 'octocat',
+      })
+    )
+
+    expect(state.activeAccountId).toBe(account.id)
+    expect(state.accountsById.work.workspace.applicationsById).toEqual({
+      [workApp.id]: workApp,
+    })
+    expect(account.workspace.applicationsById).toEqual({})
+  })
+})
+
+describe('account switching', () => {
+  test('switches token, applications, and selected application by active account', () => {
+    const state = createInitialAppState()
+    const workApp = appConfig('work-app')
+    const personalApp = appConfig('personal-app')
+
+    state.accountsById.work = createAccountProfile({
+      id: 'work',
+      label: 'Work',
+      token: 'ghp_work',
+      workspace: {
+        applicationsById: { [workApp.id]: workApp },
+        selectedApplicationId: workApp.id,
+      },
+    })
+    state.accountsById.personal = createAccountProfile({
+      id: 'personal',
+      label: 'Personal',
+      token: 'ghp_personal',
+      workspace: {
+        applicationsById: { [personalApp.id]: personalApp },
+        selectedApplicationId: personalApp.id,
+      },
+    })
+    state.activeAccountId = 'work'
+
+    expect(state.token).toBe('ghp_work')
+    expect(state.applicationsById).toEqual({ [workApp.id]: workApp })
+    expect(state.selectedApplication).toBe(workApp)
+
+    expect(setActiveAccount(state, 'personal')).toBe(true)
+
+    expect(state.token).toBe('ghp_personal')
+    expect(state.applicationsById).toEqual({
+      [personalApp.id]: personalApp,
+    })
+    expect(state.selectedApplication).toBe(personalApp)
+
+    expect(setActiveAccount(state, 'work')).toBe(true)
+    expect(state.selectedApplication).toBe(workApp)
+  })
+
+  test('does not switch to a missing account', () => {
+    const state = createInitialAppState()
+    state.accountsById.work = createAccountProfile({
+      id: 'work',
+      label: 'Work',
+      token: 'ghp_work',
+    })
+    state.activeAccountId = 'work'
+
+    expect(setActiveAccount(state, 'missing')).toBe(false)
+    expect(state.activeAccountId).toBe('work')
+  })
+
+  test('updates applications only in the active account workspace', () => {
+    const state = createInitialAppState()
+    const workApp = appConfig('work-app')
+    const personalApp = appConfig('personal-app')
+    state.accountsById.work = createAccountProfile({
+      id: 'work',
+      label: 'Work',
+      token: 'ghp_work',
+      workspace: {
+        applicationsById: { [workApp.id]: workApp },
+        selectedApplicationId: workApp.id,
+      },
+    })
+    state.accountsById.personal = createAccountProfile({
+      id: 'personal',
+      label: 'Personal',
+      token: 'ghp_personal',
+    })
+    state.activeAccountId = 'personal'
+
+    setActiveAccountApplications(state, { [personalApp.id]: personalApp })
+
+    expect(state.accountsById.work.workspace.applicationsById).toEqual({
+      [workApp.id]: workApp,
+    })
+    expect(state.accountsById.personal.workspace.applicationsById).toEqual({
+      [personalApp.id]: personalApp,
+    })
+  })
+})
+
+describe('edit account action', () => {
+  test('edits the label without validating the PAT', async () => {
+    const state = createInitialAppState()
+    state.accountsById.work = createAccountProfile({
+      id: 'work',
+      label: 'Work',
+      token: 'ghp_work',
+      githubLogin: 'work-octocat',
+      githubUserId: 'U_work',
+    })
+    state.activeAccountId = 'work'
+
+    await editAccountInState(
+      state,
+      {
+        accountId: 'work',
+        label: ' Work deploys ',
+        token: '',
+      },
+      async () => {
+        throw new Error('Unexpected validation')
+      }
+    )
+
+    expect(state.accountsById.work.label).toBe('Work deploys')
+    expect(state.accountsById.work.token).toBe('ghp_work')
+    expect(state.accountsById.work.githubLogin).toBe('work-octocat')
+  })
+
+  test('replaces a same-identity PAT while preserving the workspace', async () => {
+    const state = createInitialAppState()
+    const workApp = appConfig('work-app')
+    state.accountsById.work = createAccountProfile({
+      id: 'work',
+      label: 'Work',
+      token: 'ghp_old',
+      githubLogin: 'old-login',
+      githubUserId: 'U_work',
+      workspace: {
+        applicationsById: { [workApp.id]: workApp },
+        selectedApplicationId: workApp.id,
+        pendingDeployments: {
+          deploy: { createdAt: '2026-04-30T12:00:00.000Z' },
+        },
+      },
+    })
+    state.activeAccountId = 'work'
+
+    await editAccountInState(
+      state,
+      {
+        accountId: 'work',
+        label: 'Work',
+        token: ' ghp_new ',
+      },
+      async () => ({
+        id: 'U_work',
+        login: 'work-octocat',
+      })
+    )
+
+    expect(state.accountsById.work.token).toBe('ghp_new')
+    expect(state.accountsById.work.githubLogin).toBe('work-octocat')
+    expect(state.accountsById.work.githubUserId).toBe('U_work')
+    expect(state.accountsById.work.workspace.applicationsById).toEqual({
+      [workApp.id]: workApp,
+    })
+    expect(state.accountsById.work.workspace.selectedApplicationId).toBe(
+      workApp.id
+    )
+    expect(state.accountsById.work.workspace.pendingDeployments.deploy).toEqual({
+      createdAt: '2026-04-30T12:00:00.000Z',
+    })
+  })
+
+  test('rejects a replacement PAT for a different GitHub user', async () => {
+    const state = createInitialAppState()
+    state.accountsById.work = createAccountProfile({
+      id: 'work',
+      label: 'Work',
+      token: 'ghp_work',
+      githubLogin: 'work-octocat',
+      githubUserId: 'U_work',
+    })
+    state.activeAccountId = 'work'
+
+    let error: unknown
+    try {
+      await editAccountInState(
+        state,
+        {
+          accountId: 'work',
+          label: 'Work',
+          token: 'ghp_personal',
+        },
+        async () => ({
+          id: 'U_personal',
+          login: 'octocat',
+        })
+      )
+    } catch (caught) {
+      error = caught
+    }
+
+    expect(error).toBeInstanceOf(Error)
+    expect((error as Error).message).toContain('Add it as a new account')
+    expect(state.accountsById.work.token).toBe('ghp_work')
+    expect(state.accountsById.work.githubLogin).toBe('work-octocat')
   })
 })


### PR DESCRIPTION
## Summary

- replace the no-account entry state with a first-account setup flow
- validate PATs through an isolated GitHub identity helper before saving accounts
- add main-screen account switching plus an add-account dialog for additional accounts
- add account editing for label changes and same-identity PAT replacement while preserving the account workspace
- reduce the H1 typography scale through a theme override

## Impact

This removes the legacy single PAT field without losing the ability to switch GitHub identities. Users can now add, switch, and edit saved accounts while each account keeps its own applications and selected application.

## Validation

- `bun test` passes: 25 tests
- `bun run build` passes

Closes #17
Closes #18
Closes #20

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added multi-account support—users can now create, switch between, and manage multiple GitHub accounts.
  * Account setup wizard with guided authentication flow.
  * Edit existing accounts to update labels and authentication tokens.
  * GitHub identity verification to ensure valid authentication credentials.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->