### PR TITLE
[codex] Finish multi-account PAT switching hardening

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -30,7 +30,8 @@ const RepoPreloader = () => {
 
 const App = () => {
   const { accountsById, activeAccountId, token } = useAppState()
-  const { addAccount, editAccount, selectAccount, showSettings } = useActions()
+  const { addAccount, editAccount, removeAccount, selectAccount, showSettings } =
+    useActions()
   const hasAccounts = Object.keys(accountsById).length > 0
   const hasActiveAccountToken = hasAccounts && !!token
 
@@ -56,6 +57,7 @@ const App = () => {
               activeAccountId={activeAccountId}
               addAccount={addAccount}
               editAccount={editAccount}
+              removeAccount={removeAccount}
               selectAccount={selectAccount}
             />
             {hasActiveAccountToken ? (

--- a/src/api/fetchHooks.ts
+++ b/src/api/fetchHooks.ts
@@ -232,7 +232,10 @@ export const useFetchRepos = ({
     () => getGitHubQueryScope({ activeAccountId, token }),
     [activeAccountId, token]
   )
-  const cachedPage = useMemo(() => loadRepoCache(scope.tokenKey), [scope.tokenKey])
+  const cachedPage = useMemo(
+    () => loadRepoCache(scope.repoCacheKey),
+    [scope.repoCacheKey]
+  )
 
   const query = useInfiniteQuery({
     queryKey: githubQueryKeys.repos(scope),
@@ -273,10 +276,10 @@ export const useFetchRepos = ({
   ])
 
   useEffect(() => {
-    if (!scope.tokenKey || !query.data?.pages.length) return
+    if (!scope.repoCacheKey || !query.data?.pages.length) return
 
-    saveRepoCache(scope.tokenKey, buildRepoCache(query.data.pages))
-  }, [query.data, scope.tokenKey])
+    saveRepoCache(scope.repoCacheKey, buildRepoCache(query.data.pages))
+  }, [query.data, scope.repoCacheKey])
 
   const repos = useMemo(
     () => collectRepos(query.data?.pages ?? []),
@@ -353,11 +356,11 @@ function buildRepoCache(pages: RepoPage[]): RepoPage & { savedAt: number } {
 }
 
 function loadRepoCache(
-  tokenKey: string
+  cacheKey: string
 ): (RepoPage & { savedAt: number }) | undefined {
-  if (!tokenKey || typeof localStorage === 'undefined') return undefined
+  if (!cacheKey || typeof localStorage === 'undefined') return undefined
 
-  const value = localStorage.getItem(getRepoCacheStorageKey(tokenKey))
+  const value = localStorage.getItem(getRepoCacheStorageKey(cacheKey))
   if (!value) return undefined
 
   try {
@@ -371,14 +374,14 @@ function loadRepoCache(
 }
 
 function saveRepoCache(
-  tokenKey: string,
+  cacheKey: string,
   cache: RepoPage & { savedAt: number }
 ) {
   if (typeof localStorage === 'undefined') return
 
   try {
     localStorage.setItem(
-      getRepoCacheStorageKey(tokenKey),
+      getRepoCacheStorageKey(cacheKey),
       JSON.stringify(cache)
     )
   } catch (error) {
@@ -386,8 +389,8 @@ function saveRepoCache(
   }
 }
 
-function getRepoCacheStorageKey(tokenKey: string) {
-  return `gdc.v2.repos.${tokenKey}`
+function getRepoCacheStorageKey(cacheKey: string) {
+  return `gdc.v2.repos.${cacheKey}`
 }
 
 function tryParseWorkflowRunId(payload: string | null): number | undefined {

--- a/src/api/fetchHooks.ts
+++ b/src/api/fetchHooks.ts
@@ -1,16 +1,20 @@
 import type { components } from '@octokit/openapi-types/types'
-import { Octokit } from '@octokit/rest'
 import { useInfiniteQuery, useQuery } from '@tanstack/react-query'
 import type { UseQueryResult } from '@tanstack/react-query'
 import dayjs from 'dayjs'
-import { GraphQLClient } from 'graphql-request'
 import { keyBy, orderBy } from 'lodash-es'
 import { useEffect, useMemo } from 'react'
 import { z } from 'zod'
-import { DeploymentState, getSdk } from '../generated/graphql'
+import { DeploymentState } from '../generated/graphql'
 import type { DeployFragment, RepoFragment } from '../generated/graphql'
 import { useAppState } from '../store'
 import type { DeploymentModel, ReleaseModel } from '../store'
+import {
+  createGraphQLApi,
+  createOctokit,
+  getGitHubQueryScope,
+  githubQueryKeys,
+} from './githubRuntime'
 import {
   githubEnvironmentsSchema,
   repoSchema,
@@ -24,76 +28,6 @@ import type {
 
 const REPO_STALE_TIME_MS = 30 * 60 * 1000
 const REPO_CACHE_MAX_AGE_MS = 7 * 24 * 60 * 60 * 1000
-const GITHUB_GRAPHQL_API_URL = 'https://api.github.com/graphql'
-
-export type GitHubQueryScope = {
-  activeAccountId: string
-  tokenKey: string
-}
-
-export const getGitHubQueryScope = ({
-  activeAccountId,
-  token,
-}: {
-  activeAccountId: string
-  token: string
-}): GitHubQueryScope => ({
-  activeAccountId,
-  tokenKey: token ? hashString(token) : '',
-})
-
-export const githubQueryKeys = {
-  releases: (
-    scope: GitHubQueryScope,
-    repo: RepoModel | undefined,
-    prefix: string
-  ) =>
-    [
-      'github',
-      'releases',
-      scope.activeAccountId,
-      scope.tokenKey,
-      repo?.owner,
-      repo?.name,
-      prefix,
-    ] as const,
-  workflows: (scope: GitHubQueryScope, repo: RepoModel | undefined) =>
-    [
-      'github',
-      'workflows',
-      scope.activeAccountId,
-      scope.tokenKey,
-      repo?.owner,
-      repo?.name,
-    ] as const,
-  workflowRuns: (
-    scope: GitHubQueryScope,
-    repo: RepoModel | undefined,
-    workflowId: number | undefined,
-    workflowRuns: number
-  ) =>
-    [
-      'github',
-      'workflow-runs',
-      scope.activeAccountId,
-      scope.tokenKey,
-      repo?.owner,
-      repo?.name,
-      workflowId,
-      workflowRuns,
-    ] as const,
-  environments: (scope: GitHubQueryScope, repo: RepoModel | undefined) =>
-    [
-      'github',
-      'environments',
-      scope.activeAccountId,
-      scope.tokenKey,
-      repo?.owner,
-      repo?.name,
-    ] as const,
-  repos: (scope: GitHubQueryScope) =>
-    ['github', 'repos', scope.activeAccountId, scope.tokenKey] as const,
-}
 
 type RepoPage = {
   repos: RepoModel[]
@@ -365,20 +299,6 @@ export const useFetchRepos = ({
   }
 }
 
-function createGraphQLApi(token: string) {
-  const client = new GraphQLClient(GITHUB_GRAPHQL_API_URL, {
-    headers: {
-      Authorization: `Bearer ${token}`,
-    },
-  })
-
-  return getSdk(client)
-}
-
-function createOctokit(token: string) {
-  return new Octokit({ auth: token })
-}
-
 async function fetchRepoPage(
   token: string,
   after: string | null,
@@ -468,16 +388,6 @@ function saveRepoCache(
 
 function getRepoCacheStorageKey(tokenKey: string) {
   return `gdc.v2.repos.${tokenKey}`
-}
-
-export function hashString(value: string) {
-  let hash = 5381
-
-  for (let i = 0; i < value.length; i++) {
-    hash = (hash * 33) ^ value.charCodeAt(i)
-  }
-
-  return (hash >>> 0).toString(36)
 }
 
 function tryParseWorkflowRunId(payload: string | null): number | undefined {

--- a/src/api/fetchHooks.ts
+++ b/src/api/fetchHooks.ts
@@ -1,13 +1,15 @@
 import type { components } from '@octokit/openapi-types/types'
+import { Octokit } from '@octokit/rest'
 import { useInfiniteQuery, useQuery } from '@tanstack/react-query'
 import type { UseQueryResult } from '@tanstack/react-query'
 import dayjs from 'dayjs'
+import { GraphQLClient } from 'graphql-request'
 import { keyBy, orderBy } from 'lodash-es'
 import { useEffect, useMemo } from 'react'
 import { z } from 'zod'
-import { DeploymentState } from '../generated/graphql'
+import { DeploymentState, getSdk } from '../generated/graphql'
 import type { DeployFragment, RepoFragment } from '../generated/graphql'
-import { restApi, useAppState } from '../store'
+import { useAppState } from '../store'
 import type { DeploymentModel, ReleaseModel } from '../store'
 import {
   githubEnvironmentsSchema,
@@ -19,10 +21,79 @@ import type {
   RepoModel,
   WorkflowRun,
 } from '../state/schemas'
-import graphQLApi from '../utils/graphQLApi'
 
 const REPO_STALE_TIME_MS = 30 * 60 * 1000
 const REPO_CACHE_MAX_AGE_MS = 7 * 24 * 60 * 60 * 1000
+const GITHUB_GRAPHQL_API_URL = 'https://api.github.com/graphql'
+
+export type GitHubQueryScope = {
+  activeAccountId: string
+  tokenKey: string
+}
+
+export const getGitHubQueryScope = ({
+  activeAccountId,
+  token,
+}: {
+  activeAccountId: string
+  token: string
+}): GitHubQueryScope => ({
+  activeAccountId,
+  tokenKey: token ? hashString(token) : '',
+})
+
+export const githubQueryKeys = {
+  releases: (
+    scope: GitHubQueryScope,
+    repo: RepoModel | undefined,
+    prefix: string
+  ) =>
+    [
+      'github',
+      'releases',
+      scope.activeAccountId,
+      scope.tokenKey,
+      repo?.owner,
+      repo?.name,
+      prefix,
+    ] as const,
+  workflows: (scope: GitHubQueryScope, repo: RepoModel | undefined) =>
+    [
+      'github',
+      'workflows',
+      scope.activeAccountId,
+      scope.tokenKey,
+      repo?.owner,
+      repo?.name,
+    ] as const,
+  workflowRuns: (
+    scope: GitHubQueryScope,
+    repo: RepoModel | undefined,
+    workflowId: number | undefined,
+    workflowRuns: number
+  ) =>
+    [
+      'github',
+      'workflow-runs',
+      scope.activeAccountId,
+      scope.tokenKey,
+      repo?.owner,
+      repo?.name,
+      workflowId,
+      workflowRuns,
+    ] as const,
+  environments: (scope: GitHubQueryScope, repo: RepoModel | undefined) =>
+    [
+      'github',
+      'environments',
+      scope.activeAccountId,
+      scope.tokenKey,
+      repo?.owner,
+      repo?.name,
+    ] as const,
+  repos: (scope: GitHubQueryScope) =>
+    ['github', 'repos', scope.activeAccountId, scope.tokenKey] as const,
+}
 
 type RepoPage = {
   repos: RepoModel[]
@@ -40,28 +111,26 @@ const repoCacheSchema = z.object({
 export const useFetchReleases = () => {
   const { activeAccountId, selectedApplication, settings, token } = useAppState()
   const refreshIntervalSecs = settings.refreshIntervalSecs
-  const tokenKey = token ? hashString(token) : ''
+  const scope = getGitHubQueryScope({ activeAccountId, token })
 
   const repo = selectedApplication?.repo
   const prefix = selectedApplication?.releaseFilter ?? ''
 
   const { data, isLoading, error } = useQuery({
-    queryKey: [
-      'releases',
-      activeAccountId,
-      tokenKey,
-      repo?.owner,
-      repo?.name,
-      prefix,
-    ],
-    queryFn: async () => {
-      if (!repo) return []
+    queryKey: githubQueryKeys.releases(scope, repo, prefix),
+    enabled: !!token && !!repo,
+    queryFn: async ({ signal }) => {
+      if (!token || !repo) return []
 
-      const result = await graphQLApi.fetchReleases({
-        repoName: repo.name,
-        repoOwner: repo.owner,
-        prefix,
-      })
+      const result = await createGraphQLApi(token).fetchReleases(
+        {
+          repoName: repo.name,
+          repoOwner: repo.owner,
+          prefix,
+        },
+        undefined,
+        signal
+      )
       const fragments = result.repository?.refs?.nodes?.map((n) => n!) ?? []
       const releases = fragments
         .map(({ id, name, target }): ReleaseModel | null =>
@@ -112,23 +181,26 @@ type Workflow = components['schemas']['workflow']
 
 export const useFetchWorkflows = () => {
   const { activeAccountId, token, selectedApplication } = useAppState()
-  const tokenKey = token ? hashString(token) : ''
+  const scope = getGitHubQueryScope({ activeAccountId, token })
 
   const repo = selectedApplication?.repo
 
   const { data, isLoading, error } = useQuery({
-    queryKey: ['workflows', activeAccountId, tokenKey, repo?.owner, repo?.name],
-    queryFn: async () => {
+    queryKey: githubQueryKeys.workflows(scope, repo),
+    enabled: !!token && !!repo,
+    queryFn: async ({ signal }) => {
       if (!token || !repo) return []
 
       const { owner, name } = repo
+      const octokit = createOctokit(token)
 
-      const response = await restApi.octokit.paginate(
-        restApi.octokit.actions.listRepoWorkflows,
+      const response = await octokit.paginate(
+        octokit.actions.listRepoWorkflows,
         {
           owner,
           repo: name,
           per_page: 100,
+          request: { signal },
         },
         (response) => response.data as Workflow[]
       )
@@ -145,31 +217,30 @@ export const useFetchWorkflowRuns = (): UseQueryResult<
 > => {
   const { activeAccountId, token, selectedApplication, settings } =
     useAppState()
-  const tokenKey = token ? hashString(token) : ''
+  const scope = getGitHubQueryScope({ activeAccountId, token })
   const workflowRuns = settings.workflowRuns
 
   const repo = selectedApplication?.repo
   const workflowId = selectedApplication?.deploySettings?.workflowId
   return useQuery({
-    queryKey: [
-      'workflow-runs',
-      activeAccountId,
-      tokenKey,
-      repo?.owner,
-      repo?.name,
+    queryKey: githubQueryKeys.workflowRuns(
+      scope,
+      repo,
       workflowId,
-      workflowRuns,
-    ],
-    queryFn: async () => {
+      workflowRuns
+    ),
+    enabled: !!token && !!repo && !!workflowId,
+    queryFn: async ({ signal }) => {
       if (!token || !repo || !workflowId) return {}
 
       const { owner, name } = repo
 
-      const { data } = await restApi.octokit.actions.listWorkflowRuns({
+      const { data } = await createOctokit(token).actions.listWorkflowRuns({
         workflow_id: workflowId,
         owner,
         repo: name,
         per_page: workflowRuns,
+        request: { signal },
       })
 
       let workflows: WorkflowRun[] = []
@@ -187,28 +258,25 @@ export const useFetchWorkflowRuns = (): UseQueryResult<
 
 export const useFetchEnvironments = (): UseQueryResult<GitHubEnvironment[]> => {
   const { activeAccountId, token, selectedApplication } = useAppState()
-  const tokenKey = token ? hashString(token) : ''
+  const scope = getGitHubQueryScope({ activeAccountId, token })
 
   const repo = selectedApplication?.repo
 
   return useQuery({
-    queryKey: [
-      'environments',
-      activeAccountId,
-      tokenKey,
-      repo?.owner,
-      repo?.name,
-    ],
-    queryFn: async () => {
+    queryKey: githubQueryKeys.environments(scope, repo),
+    enabled: !!token && !!repo,
+    queryFn: async ({ signal }) => {
       if (!token || !repo) return []
       const { owner, name } = repo
+      const octokit = createOctokit(token)
 
-      const data = await restApi.octokit.paginate(
-        restApi.octokit.repos.getAllEnvironments,
+      const data = await octokit.paginate(
+        octokit.repos.getAllEnvironments,
         {
           owner,
           repo: name,
           per_page: 100,
+          request: { signal },
         },
         (response) => response.data as any
       )
@@ -226,11 +294,14 @@ export const useFetchRepos = ({
   autoFetchAll = false,
 }: { autoFetchAll?: boolean } = {}) => {
   const { activeAccountId, token } = useAppState()
-  const tokenKey = useMemo(() => (token ? hashString(token) : ''), [token])
-  const cachedPage = useMemo(() => loadRepoCache(tokenKey), [tokenKey])
+  const scope = useMemo(
+    () => getGitHubQueryScope({ activeAccountId, token }),
+    [activeAccountId, token]
+  )
+  const cachedPage = useMemo(() => loadRepoCache(scope.tokenKey), [scope.tokenKey])
 
   const query = useInfiniteQuery({
-    queryKey: ['repos', activeAccountId, tokenKey],
+    queryKey: githubQueryKeys.repos(scope),
     enabled: !!token,
     staleTime: REPO_STALE_TIME_MS,
     gcTime: REPO_CACHE_MAX_AGE_MS,
@@ -242,7 +313,8 @@ export const useFetchRepos = ({
         }
       : undefined,
     initialDataUpdatedAt: cachedPage?.savedAt,
-    queryFn: ({ pageParam, signal }) => fetchRepoPage(pageParam, signal),
+    queryFn: ({ pageParam, signal }) =>
+      fetchRepoPage(token, pageParam, signal),
     getNextPageParam: (lastPage) => lastPage.nextCursor ?? undefined,
   })
 
@@ -267,10 +339,10 @@ export const useFetchRepos = ({
   ])
 
   useEffect(() => {
-    if (!tokenKey || !query.data?.pages.length) return
+    if (!scope.tokenKey || !query.data?.pages.length) return
 
-    saveRepoCache(tokenKey, buildRepoCache(query.data.pages))
-  }, [query.data, tokenKey])
+    saveRepoCache(scope.tokenKey, buildRepoCache(query.data.pages))
+  }, [query.data, scope.tokenKey])
 
   const repos = useMemo(
     () => collectRepos(query.data?.pages ?? []),
@@ -293,11 +365,26 @@ export const useFetchRepos = ({
   }
 }
 
+function createGraphQLApi(token: string) {
+  const client = new GraphQLClient(GITHUB_GRAPHQL_API_URL, {
+    headers: {
+      Authorization: `Bearer ${token}`,
+    },
+  })
+
+  return getSdk(client)
+}
+
+function createOctokit(token: string) {
+  return new Octokit({ auth: token })
+}
+
 async function fetchRepoPage(
+  token: string,
   after: string | null,
   signal: AbortSignal
 ): Promise<RepoPage> {
-  const result = await graphQLApi.fetchReposWithWriteAccess(
+  const result = await createGraphQLApi(token).fetchReposWithWriteAccess(
     { after },
     undefined,
     signal
@@ -383,7 +470,7 @@ function getRepoCacheStorageKey(tokenKey: string) {
   return `gdc.v2.repos.${tokenKey}`
 }
 
-function hashString(value: string) {
+export function hashString(value: string) {
   let hash = 5381
 
   for (let i = 0; i < value.length; i++) {

--- a/src/api/githubRuntime.ts
+++ b/src/api/githubRuntime.ts
@@ -1,0 +1,99 @@
+import { Octokit } from '@octokit/rest'
+import { GraphQLClient } from 'graphql-request'
+import { getSdk } from '../generated/graphql'
+import type { RepoModel } from '../state/schemas'
+
+const GITHUB_GRAPHQL_API_URL = 'https://api.github.com/graphql'
+
+export type GitHubQueryScope = {
+  activeAccountId: string
+  tokenKey: string
+}
+
+export const getGitHubQueryScope = ({
+  activeAccountId,
+  token,
+}: {
+  activeAccountId: string
+  token: string
+}): GitHubQueryScope => ({
+  activeAccountId,
+  tokenKey: token ? hashString(token) : '',
+})
+
+export const githubQueryKeys = {
+  releases: (
+    scope: GitHubQueryScope,
+    repo: RepoModel | undefined,
+    prefix: string
+  ) =>
+    [
+      'github',
+      'releases',
+      scope.activeAccountId,
+      scope.tokenKey,
+      repo?.owner,
+      repo?.name,
+      prefix,
+    ] as const,
+  workflows: (scope: GitHubQueryScope, repo: RepoModel | undefined) =>
+    [
+      'github',
+      'workflows',
+      scope.activeAccountId,
+      scope.tokenKey,
+      repo?.owner,
+      repo?.name,
+    ] as const,
+  workflowRuns: (
+    scope: GitHubQueryScope,
+    repo: RepoModel | undefined,
+    workflowId: number | undefined,
+    workflowRuns: number
+  ) =>
+    [
+      'github',
+      'workflow-runs',
+      scope.activeAccountId,
+      scope.tokenKey,
+      repo?.owner,
+      repo?.name,
+      workflowId,
+      workflowRuns,
+    ] as const,
+  environments: (scope: GitHubQueryScope, repo: RepoModel | undefined) =>
+    [
+      'github',
+      'environments',
+      scope.activeAccountId,
+      scope.tokenKey,
+      repo?.owner,
+      repo?.name,
+    ] as const,
+  repos: (scope: GitHubQueryScope) =>
+    ['github', 'repos', scope.activeAccountId, scope.tokenKey] as const,
+}
+
+export function createGraphQLApi(token: string) {
+  const client = new GraphQLClient(GITHUB_GRAPHQL_API_URL, {
+    headers: {
+      Authorization: `Bearer ${token}`,
+    },
+  })
+
+  return getSdk(client)
+}
+
+export function createOctokit(token: string) {
+  return new Octokit({ auth: token })
+}
+
+export function hashString(value: string) {
+  let hash = 5381
+
+  for (let i = 0; i < value.length; i++) {
+    hash = (hash * 33) ^ value.charCodeAt(i)
+  }
+
+  return (hash >>> 0).toString(36)
+}

--- a/src/api/githubRuntime.ts
+++ b/src/api/githubRuntime.ts
@@ -8,6 +8,7 @@ const GITHUB_GRAPHQL_API_URL = 'https://api.github.com/graphql'
 export type GitHubQueryScope = {
   activeAccountId: string
   tokenKey: string
+  repoCacheKey: string
 }
 
 export const getGitHubQueryScope = ({
@@ -18,8 +19,18 @@ export const getGitHubQueryScope = ({
   token: string
 }): GitHubQueryScope => ({
   activeAccountId,
-  tokenKey: token ? hashString(token) : '',
+  ...getGitHubTokenScope(activeAccountId, token),
 })
+
+function getGitHubTokenScope(activeAccountId: string, token: string) {
+  const tokenKey = token ? hashString(token) : ''
+
+  return {
+    tokenKey,
+    repoCacheKey:
+      activeAccountId && tokenKey ? `${activeAccountId}:${tokenKey}` : '',
+  }
+}
 
 export const githubQueryKeys = {
   releases: (

--- a/src/components/AccountEditView.tsx
+++ b/src/components/AccountEditView.tsx
@@ -2,29 +2,44 @@ import { Alert, Box, Button, Icon, TextField, Typography } from '@mui/material'
 import { useState } from 'react'
 import type { FormEvent } from 'react'
 import type { AccountProfile } from '../state/schemas'
-import type { EditAccountInput } from '../store/actions'
+import {
+  DifferentIdentityTokenError,
+  type AddAccountInput,
+  type EditAccountInput,
+} from '../store/actions'
 
 type AccountEditViewProps = {
   account: AccountProfile
+  addAccount: (input: AddAccountInput) => Promise<unknown>
   editAccount: (input: EditAccountInput) => Promise<unknown>
+  removeAccount: (accountId: string) => Promise<boolean>
   onSaved?: () => void
 }
 
 export function AccountEditView({
   account,
+  addAccount,
   editAccount,
+  removeAccount,
   onSaved,
 }: AccountEditViewProps) {
   const [label, setLabel] = useState(account.label)
   const [token, setToken] = useState('')
   const [error, setError] = useState<string>()
+  const [differentIdentity, setDifferentIdentity] =
+    useState<DifferentIdentityTokenError>()
   const [isSaving, setIsSaving] = useState(false)
+  const [isRemoving, setIsRemoving] = useState(false)
+  const [isAddingDifferentIdentity, setIsAddingDifferentIdentity] =
+    useState(false)
 
-  const canSave = !!label.trim() && !isSaving
+  const canSave =
+    !!label.trim() && !isSaving && !isRemoving && !isAddingDifferentIdentity
 
   const handleSubmit = async (event: FormEvent<HTMLFormElement>) => {
     event.preventDefault()
     setError(undefined)
+    setDifferentIdentity(undefined)
     setIsSaving(true)
 
     try {
@@ -35,6 +50,9 @@ export function AccountEditView({
       })
       onSaved?.()
     } catch (error) {
+      if (error instanceof DifferentIdentityTokenError) {
+        setDifferentIdentity(error)
+      }
       setError(
         error instanceof Error
           ? error.message
@@ -42,6 +60,48 @@ export function AccountEditView({
       )
     } finally {
       setIsSaving(false)
+    }
+  }
+
+  const handleAddDifferentIdentity = async () => {
+    if (!differentIdentity) return
+
+    setError(undefined)
+    setIsAddingDifferentIdentity(true)
+    try {
+      await addAccount({
+        label: differentIdentity.replacementIdentity.login,
+        token,
+      })
+      onSaved?.()
+    } catch (error) {
+      setError(
+        error instanceof Error
+          ? error.message
+          : 'Could not add that account. Check the token and try again.'
+      )
+    } finally {
+      setIsAddingDifferentIdentity(false)
+    }
+  }
+
+  const handleRemove = async () => {
+    setError(undefined)
+    setDifferentIdentity(undefined)
+    setIsRemoving(true)
+    try {
+      const removed = await removeAccount(account.id)
+      if (removed) {
+        onSaved?.()
+      }
+    } catch (error) {
+      setError(
+        error instanceof Error
+          ? error.message
+          : 'Could not remove that account.'
+      )
+    } finally {
+      setIsRemoving(false)
     }
   }
 
@@ -61,6 +121,26 @@ export function AccountEditView({
         </Typography>
       </Box>
       {error ? <Alert severity="error">{error}</Alert> : null}
+      {differentIdentity ? (
+        <Alert
+          severity="warning"
+          action={
+            <Button
+              color="inherit"
+              size="small"
+              disabled={isAddingDifferentIdentity}
+              onClick={handleAddDifferentIdentity}
+            >
+              {isAddingDifferentIdentity
+                ? 'Adding...'
+                : `Add @${differentIdentity.replacementIdentity.login}`}
+            </Button>
+          }
+        >
+          Keep this workspace on @{account.githubLogin ?? account.label}, or add
+          the new identity as a separate account.
+        </Alert>
+      ) : null}
       <TextField
         label="Account label"
         value={label}
@@ -76,7 +156,15 @@ export function AccountEditView({
         autoComplete="off"
         helperText="Leave blank to keep the current token. Replacements must belong to the same GitHub user."
       />
-      <Box sx={{ display: 'flex', justifyContent: 'flex-end' }}>
+      <Box sx={{ display: 'flex', justifyContent: 'space-between', gap: 1 }}>
+        <Button
+          color="error"
+          disabled={isRemoving || isSaving || isAddingDifferentIdentity}
+          startIcon={<Icon>delete</Icon>}
+          onClick={handleRemove}
+        >
+          {isRemoving ? 'Removing account...' : 'Remove account'}
+        </Button>
         <Button
           type="submit"
           variant="contained"

--- a/src/components/AccountSwitcherView.tsx
+++ b/src/components/AccountSwitcherView.tsx
@@ -21,6 +21,7 @@ type AccountSwitcherViewProps = {
   activeAccountId: string
   addAccount: (input: AddAccountInput) => Promise<unknown>
   editAccount: (input: EditAccountInput) => Promise<unknown>
+  removeAccount: (accountId: string) => Promise<boolean>
   selectAccount: (accountId: string) => void
 }
 
@@ -29,6 +30,7 @@ export function AccountSwitcherView({
   activeAccountId,
   addAccount,
   editAccount,
+  removeAccount,
   selectAccount,
 }: AccountSwitcherViewProps) {
   const [addDialogOpen, setAddDialogOpen] = useState(false)
@@ -114,7 +116,9 @@ export function AccountSwitcherView({
           {activeAccount ? (
             <AccountEditView
               account={activeAccount}
+              addAccount={addAccount}
               editAccount={editAccount}
+              removeAccount={removeAccount}
               onSaved={() => setEditDialogOpen(false)}
             />
           ) : null}

--- a/src/components/ApplicationDialog.tsx
+++ b/src/components/ApplicationDialog.tsx
@@ -16,6 +16,7 @@ import { useActions, useAppState } from '../store'
 import type { ApplicationDialogState } from '../store'
 import type { RepoModel } from '../state/schemas'
 import { theme } from '../theme'
+import { CredentialErrorAlert } from './CredentialErrorAlert'
 import Expander from './Expander'
 import { RepoSearchBox } from './RepoSearchView'
 
@@ -58,7 +59,7 @@ export const ApplicationDialog: FC<{
           <DialogTitle>{title}</DialogTitle>
           <DialogContent>
             {error instanceof Error ? (
-              <Alert severity="error">{error.message}</Alert>
+              <CredentialErrorAlert title="Could not load repositories" />
             ) : (
               <Stack sx={{ gap: 1 }}>
                 <Stack sx={{ gap: 2 }}>

--- a/src/components/CredentialErrorAlert.tsx
+++ b/src/components/CredentialErrorAlert.tsx
@@ -1,0 +1,15 @@
+import { Alert, AlertTitle } from '@mui/material'
+
+export function CredentialErrorAlert({
+  title = 'Could not load GitHub data',
+}: {
+  title?: string
+}) {
+  return (
+    <Alert severity="error">
+      <AlertTitle>{title}</AlertTitle>
+      Your personal access token may be expired or revoked. Edit the active
+      account and replace the token, then try again.
+    </Alert>
+  )
+}

--- a/src/components/ReleasesTableView.tsx
+++ b/src/components/ReleasesTableView.tsx
@@ -22,6 +22,7 @@ import { DeploymentState } from '../generated/graphql'
 import type { EnvironmentSettings, WorkflowRun } from '../state/schemas'
 import type { DeploymentModel, ReleaseModel } from '../store'
 import { getDeploymentId, useActions, useAppState } from '../store'
+import { CredentialErrorAlert } from './CredentialErrorAlert'
 
 const getButtonStyle = (state?: DeploymentState) => {
   switch (state) {
@@ -45,7 +46,8 @@ export const ReleasesTableView = () => {
   const repo = selectedApplication?.repo
   const { triggerDeployment, removeEnvironment } = useActions()
   const allReleaseResultsForTag = useFetchReleases()
-  const { data: workflowRuns = [] } = useFetchWorkflowRuns()
+  const workflowRunsQuery = useFetchWorkflowRuns()
+  const { data: workflowRuns = [] } = workflowRunsQuery
 
   const releases = allReleaseResultsForTag.data || []
 
@@ -71,6 +73,14 @@ export const ReleasesTableView = () => {
 
   if (allReleaseResultsForTag.isLoading) {
     return <CircularProgress />
+  }
+
+  if (allReleaseResultsForTag.error) {
+    return <CredentialErrorAlert title="Could not load releases" />
+  }
+
+  if (workflowRunsQuery.error) {
+    return <CredentialErrorAlert title="Could not load workflow runs" />
   }
 
   const releasesSorted = orderBy(

--- a/src/components/SelectWorkflow.tsx
+++ b/src/components/SelectWorkflow.tsx
@@ -1,5 +1,4 @@
 import {
-  Alert,
   CircularProgress,
   FormControl,
   InputLabel,
@@ -9,6 +8,7 @@ import {
 import type { FormControlProps } from '@mui/material'
 import { useFetchWorkflows } from '../api/fetchHooks'
 import { useAppState } from '../store'
+import { CredentialErrorAlert } from './CredentialErrorAlert'
 
 enum WorkflowRelevance {
   None = 0,
@@ -32,7 +32,7 @@ export function SelectWorkflow({
   if (!selectedApplication) return null
 
   if (workflows.error) {
-    return <Alert severity="error">Could not load workflows</Alert>
+    return <CredentialErrorAlert title="Could not load workflows" />
   }
 
   const workflowsSorted = (workflows.data ?? []).orderBy(

--- a/src/components/WorkflowInfoView.tsx
+++ b/src/components/WorkflowInfoView.tsx
@@ -2,6 +2,7 @@ import { Icon, Link, Typography } from '@mui/material'
 import type { LinkProps } from '@mui/material'
 import { useFetchWorkflows } from '../api/fetchHooks'
 import { useAppState } from '../store'
+import { CredentialErrorAlert } from './CredentialErrorAlert'
 
 const ExternalLink = ({ children, ...props }: LinkProps) => (
   <Link
@@ -21,6 +22,10 @@ const ExternalLink = ({ children, ...props }: LinkProps) => (
 const WorkflowInfoView = () => {
   const { selectedApplication } = useAppState()
   const workflows = useFetchWorkflows()
+
+  if (workflows.error) {
+    return <CredentialErrorAlert title="Could not load workflows" />
+  }
 
   if (!selectedApplication?.deploySettings?.workflowId || !workflows.data) {
     return null

--- a/src/store/accounts.ts
+++ b/src/store/accounts.ts
@@ -107,6 +107,15 @@ export function addAccountProfile(
   return account
 }
 
+export function findAccountByGitHubUserId(
+  state: AccountContainerState,
+  githubUserId: string
+) {
+  return Object.values(state.accountsById).find(
+    (account) => account.githubUserId === githubUserId
+  )
+}
+
 export function normalizeSelectedApplicationId(
   applicationsById: Record<string, ApplicationConfig>,
   selectedApplicationId?: string
@@ -150,6 +159,22 @@ export function updateAccountProfile(
   }
   if (update.githubUserId !== undefined) {
     account.githubUserId = update.githubUserId
+  }
+
+  return account
+}
+
+export function removeAccountProfile(
+  state: AccountContainerState,
+  accountId: string
+) {
+  const account = state.accountsById[accountId]
+  if (!account) return undefined
+
+  delete state.accountsById[accountId]
+
+  if (state.activeAccountId === accountId) {
+    state.activeAccountId = Object.keys(state.accountsById)[0] ?? ''
   }
 
   return account

--- a/src/store/actions.ts
+++ b/src/store/actions.ts
@@ -492,12 +492,13 @@ export const importApplicationsToState = async (
 ) => {
   const json = await upload()
   if (json) {
-    const imported = JSON.parse(json)
     let applications: Record<string, ApplicationConfig> = {}
     try {
+      const imported = JSON.parse(json)
       applications = applicationsByIdSchema.parse(imported)
-    } catch (e) {
-      console.error(e)
+    } catch (error) {
+      console.error('Could not import applications JSON', error)
+      return
     }
     const workspace = getActiveWorkspace(state)
     const merged = mergeImportedApplications(

--- a/src/store/actions.ts
+++ b/src/store/actions.ts
@@ -1,12 +1,13 @@
 import dayjs from 'dayjs'
 import { clone, some } from 'lodash-es'
-import { snapshot } from 'valtio/vanilla'
 import {
   applicationsByIdSchema,
   createApplicationConfig,
 } from '../state/schemas'
 import type {
+  AccountProfile,
   AppSettings,
+  ApplicationConfig,
   DeploySettings,
   EnvironmentSettings,
   RepoModel,
@@ -19,14 +20,16 @@ import { showConfirm } from '../utils/dialog'
 import {
   addAccountProfile,
   deleteActiveApplication,
+  findAccountByGitHubUserId,
   getActiveWorkspace,
   getSelectedApplication,
+  removeAccountProfile,
   selectActiveApplication,
   setActiveAccount,
-  setActiveAccountApplications,
   setActiveAccountToken,
   updateAccountProfile,
 } from './accounts'
+import { mergeImportedApplications } from './applicationImport'
 import { appState } from './state'
 import { createApplicationDialogState } from './state'
 import type {
@@ -45,6 +48,24 @@ export const setToken = (token: string) => {
 export type AddAccountInput = {
   label: string
   token: string
+}
+
+export class DifferentIdentityTokenError extends Error {
+  constructor({
+    currentAccount,
+    replacementIdentity,
+  }: {
+    currentAccount: AccountProfile
+    replacementIdentity: { id: string; login: string }
+  }) {
+    super(
+      `That token belongs to @${replacementIdentity.login}, not @${currentAccount.githubLogin ?? currentAccount.label}. Add it as a new account instead.`
+    )
+    this.name = 'DifferentIdentityTokenError'
+    this.replacementIdentity = replacementIdentity
+  }
+
+  replacementIdentity: { id: string; login: string }
 }
 
 export async function addAccountToState(
@@ -70,6 +91,18 @@ export async function addAccountToState(
     throw new Error(
       'Could not validate that personal access token. Check the token and try again.'
     )
+  }
+
+  const existingAccount = findAccountByGitHubUserId(state, identity.id)
+  if (existingAccount) {
+    updateAccountProfile(state, existingAccount.id, {
+      label: normalizedLabel,
+      token: normalizedToken,
+      githubLogin: identity.login,
+      githubUserId: identity.id,
+    })
+    setActiveAccount(state, existingAccount.id)
+    return existingAccount
   }
 
   return addAccountProfile(state, {
@@ -122,9 +155,10 @@ export async function editAccountInState(
   }
 
   if (account.githubUserId && identity.id !== account.githubUserId) {
-    throw new Error(
-      `That token belongs to @${identity.login}, not @${account.githubLogin ?? account.label}. Add it as a new account instead.`
-    )
+    throw new DifferentIdentityTokenError({
+      currentAccount: account,
+      replacementIdentity: identity,
+    })
   }
 
   return updateAccountProfile(state, accountId, {
@@ -141,6 +175,37 @@ export const editAccount = (input: EditAccountInput) =>
 export const selectAccount = (accountId: string) => {
   setActiveAccount(appState, accountId)
 }
+
+export async function removeAccountFromState(
+  state: AppState,
+  accountId: string,
+  confirm: (message: string) => Promise<boolean> = showConfirm
+) {
+  const account = state.accountsById[accountId]
+  if (!account) {
+    throw new Error('Account not found.')
+  }
+
+  const applicationCount = Object.keys(
+    account.workspace.applicationsById
+  ).length
+  const applicationNoun =
+    applicationCount === 1 ? 'application' : 'applications'
+  const accountName = account.githubLogin
+    ? `${account.label} (@${account.githubLogin})`
+    : account.label
+
+  const confirmed = await confirm(
+    `Remove ${accountName}? This will delete ${applicationCount} ${applicationNoun} saved in this account.`
+  )
+  if (!confirmed) return false
+
+  removeAccountProfile(state, accountId)
+  return true
+}
+
+export const removeAccount = (accountId: string) =>
+  removeAccountFromState(appState, accountId)
 
 export const showSettings = () => (appState.settingsDialog = {})
 
@@ -407,28 +472,46 @@ export const removeEnvironment = async (name: string) => {
   }
 }
 
-export const exportApplications = async () => {
-  await downloadJson(
-    snapshot(getActiveWorkspace(appState).applicationsById),
+export const exportApplicationsFromState = async (
+  state: AppState,
+  download: typeof downloadJson = downloadJson
+) => {
+  await download(
+    { ...getActiveWorkspace(state).applicationsById },
     'gdc-applications.json'
   )
 }
 
-export const importApplications = async () => {
-  const json = await uploadJson()
+export const exportApplications = async () => {
+  await exportApplicationsFromState(appState)
+}
+
+export const importApplicationsToState = async (
+  state: AppState,
+  upload: typeof uploadJson = uploadJson
+) => {
+  const json = await upload()
   if (json) {
     const imported = JSON.parse(json)
-    let applications = {}
+    let applications: Record<string, ApplicationConfig> = {}
     try {
       applications = applicationsByIdSchema.parse(imported)
     } catch (e) {
       console.error(e)
     }
-    setActiveAccountApplications(appState, {
-      ...snapshot(getActiveWorkspace(appState).applicationsById),
-      ...applications,
-    })
+    const workspace = getActiveWorkspace(state)
+    const merged = mergeImportedApplications(
+      { ...workspace.applicationsById },
+      workspace.selectedApplicationId,
+      applications
+    )
+    workspace.applicationsById = merged.applicationsById
+    workspace.selectedApplicationId = merged.selectedApplicationId
   }
+}
+
+export const importApplications = async () => {
+  await importApplicationsToState(appState)
 }
 
 export const actions = {
@@ -446,6 +529,7 @@ export const actions = {
   exportApplications,
   hideSettings,
   importApplications,
+  removeAccount,
   removeEnvironment,
   saveApplication,
   saveDeployment,

--- a/src/store/applicationImport.ts
+++ b/src/store/applicationImport.ts
@@ -1,0 +1,79 @@
+import { v4 as uuid } from 'uuid'
+import type { ApplicationConfig } from '../state/schemas'
+import { normalizeSelectedApplicationId } from './accounts'
+
+type CreateId = () => string
+
+export type ApplicationImportMergeResult = {
+  applicationsById: Record<string, ApplicationConfig>
+  selectedApplicationId: string
+  importedApplicationIds: string[]
+}
+
+export function mergeImportedApplications(
+  existingApplicationsById: Record<string, ApplicationConfig>,
+  selectedApplicationId: string,
+  importedApplicationsById: Record<string, ApplicationConfig>,
+  createId: CreateId = uuid
+): ApplicationImportMergeResult {
+  const applicationsById = { ...existingApplicationsById }
+  const usedApplicationIds = new Set(Object.keys(applicationsById))
+  const importedApplicationIds: string[] = []
+
+  for (const importedApplication of Object.values(importedApplicationsById)) {
+    const application = cloneApplicationConfig(importedApplication)
+    const applicationId = usedApplicationIds.has(application.id)
+      ? createUniqueApplicationId(usedApplicationIds, createId)
+      : application.id
+
+    application.id = applicationId
+    applicationsById[applicationId] = application
+    usedApplicationIds.add(applicationId)
+    importedApplicationIds.push(applicationId)
+  }
+
+  const normalizedSelection = normalizeSelectedApplicationId(
+    applicationsById,
+    selectedApplicationId
+  )
+
+  return {
+    applicationsById,
+    selectedApplicationId:
+      selectedApplicationId || !importedApplicationIds.length
+        ? normalizedSelection
+        : importedApplicationIds[0],
+    importedApplicationIds,
+  }
+}
+
+function createUniqueApplicationId(
+  usedApplicationIds: Set<string>,
+  createId: CreateId
+) {
+  let id = createId()
+
+  while (usedApplicationIds.has(id)) {
+    id = createId()
+  }
+
+  return id
+}
+
+function cloneApplicationConfig(
+  application: ApplicationConfig
+): ApplicationConfig {
+  return {
+    ...application,
+    repo: { ...application.repo },
+    deploySettings: {
+      ...application.deploySettings,
+      extraArgs: { ...application.deploySettings.extraArgs },
+    },
+    environmentSettingsByName: Object.fromEntries(
+      Object.entries(application.environmentSettingsByName).map(
+        ([name, settings]) => [name, { ...settings }]
+      )
+    ),
+  }
+}

--- a/tests/api/fetchHooks.test.ts
+++ b/tests/api/fetchHooks.test.ts
@@ -23,8 +23,27 @@ describe('GitHub query keys', () => {
     expect(scope).toEqual({
       activeAccountId: 'work',
       tokenKey: hashString('ghp_secret'),
+      repoCacheKey: `work:${hashString('ghp_secret')}`,
     })
     expect(JSON.stringify(scope)).not.toContain('ghp_secret')
+  })
+
+  test('repository cache scope changes across accounts even for the same token', () => {
+    const workScope = getGitHubQueryScope({
+      activeAccountId: 'work',
+      token: 'ghp_shared',
+    })
+    const personalScope = getGitHubQueryScope({
+      activeAccountId: 'personal',
+      token: 'ghp_shared',
+    })
+
+    expect(workScope.tokenKey).toBe(personalScope.tokenKey)
+    expect(workScope.repoCacheKey).not.toBe(personalScope.repoCacheKey)
+    expect(workScope.repoCacheKey).toBe(`work:${workScope.tokenKey}`)
+    expect(personalScope.repoCacheKey).toBe(
+      `personal:${personalScope.tokenKey}`
+    )
   })
 
   test('all GitHub-backed query keys include the active account scope', () => {

--- a/tests/api/fetchHooks.test.ts
+++ b/tests/api/fetchHooks.test.ts
@@ -1,0 +1,50 @@
+import { describe, expect, test } from 'bun:test'
+import {
+  getGitHubQueryScope,
+  githubQueryKeys,
+  hashString,
+} from '../../src/api/fetchHooks'
+import type { RepoModel } from '../../src/state/schemas'
+
+const repo: RepoModel = {
+  id: 'repo-1',
+  owner: 'octo',
+  name: 'deploy-center',
+  defaultBranch: 'main',
+}
+
+describe('GitHub query keys', () => {
+  test('scope includes active account id and a token hash, never the raw token', () => {
+    const scope = getGitHubQueryScope({
+      activeAccountId: 'work',
+      token: 'ghp_secret',
+    })
+
+    expect(scope).toEqual({
+      activeAccountId: 'work',
+      tokenKey: hashString('ghp_secret'),
+    })
+    expect(JSON.stringify(scope)).not.toContain('ghp_secret')
+  })
+
+  test('all GitHub-backed query keys include the active account scope', () => {
+    const scope = getGitHubQueryScope({
+      activeAccountId: 'personal',
+      token: 'ghp_personal',
+    })
+
+    const keys = [
+      githubQueryKeys.releases(scope, repo, 'app-v'),
+      githubQueryKeys.workflows(scope, repo),
+      githubQueryKeys.workflowRuns(scope, repo, 123, 50),
+      githubQueryKeys.environments(scope, repo),
+      githubQueryKeys.repos(scope),
+    ]
+
+    for (const key of keys) {
+      expect(key).toContain('personal')
+      expect(key).toContain(scope.tokenKey)
+      expect(JSON.stringify(key)).not.toContain('ghp_personal')
+    }
+  })
+})

--- a/tests/api/fetchHooks.test.ts
+++ b/tests/api/fetchHooks.test.ts
@@ -3,7 +3,7 @@ import {
   getGitHubQueryScope,
   githubQueryKeys,
   hashString,
-} from '../../src/api/fetchHooks'
+} from '../../src/api/githubRuntime'
 import type { RepoModel } from '../../src/state/schemas'
 
 const repo: RepoModel = {

--- a/tests/components/AccountSwitcherView.test.tsx
+++ b/tests/components/AccountSwitcherView.test.tsx
@@ -4,7 +4,10 @@ import { cleanup, render, waitFor, within } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 import { createAccountProfile } from '../../src/store/accounts'
 import { AccountSwitcherView } from '../../src/components/AccountSwitcherView'
-import type { AddAccountInput } from '../../src/store/actions'
+import {
+  DifferentIdentityTokenError,
+  type AddAccountInput,
+} from '../../src/store/actions'
 
 afterEach(() => {
   cleanup()
@@ -36,6 +39,7 @@ describe('AccountSwitcherView', () => {
         activeAccountId="work"
         addAccount={async () => {}}
         editAccount={async () => {}}
+        removeAccount={async () => true}
         selectAccount={(accountId) => selectedAccountIds.push(accountId)}
       />
     )
@@ -67,6 +71,7 @@ describe('AccountSwitcherView', () => {
           submitted.push(input)
         }}
         editAccount={async () => {}}
+        removeAccount={async () => true}
         selectAccount={() => {}}
       />
     )
@@ -108,6 +113,7 @@ describe('AccountSwitcherView', () => {
         editAccount={async (input) => {
           submitted.push(input)
         }}
+        removeAccount={async () => true}
         selectAccount={() => {}}
       />
     )
@@ -138,6 +144,96 @@ describe('AccountSwitcherView', () => {
           token: '',
         },
       ])
+    })
+  })
+
+  test('offers to add a different replacement identity as a new account', async () => {
+    const added: AddAccountInput[] = []
+    const user = userEvent.setup()
+    const account = createAccountProfile({
+      id: 'work',
+      label: 'Work',
+      token: 'ghp_work',
+      githubLogin: 'work-octocat',
+      githubUserId: 'U_work',
+    })
+
+    const { getByRole } = render(
+      <AccountSwitcherView
+        accountsById={{ work: account }}
+        activeAccountId="work"
+        addAccount={async (input) => {
+          added.push(input)
+        }}
+        editAccount={async () => {
+          throw new DifferentIdentityTokenError({
+            currentAccount: account,
+            replacementIdentity: {
+              id: 'U_personal',
+              login: 'octocat',
+            },
+          })
+        }}
+        removeAccount={async () => true}
+        selectAccount={() => {}}
+      />
+    )
+
+    await user.click(getByRole('button', { name: /edit account/i }))
+    const dialog = getByRole('dialog')
+    await user.type(
+      within(dialog).getByLabelText(/replace personal access token/i),
+      'ghp_personal'
+    )
+    await user.click(
+      within(dialog).getByRole('button', { name: /save account/i })
+    )
+    await user.click(
+      await within(dialog).findByRole('button', { name: /add @octocat/i })
+    )
+
+    await waitFor(() => {
+      expect(added).toEqual([
+        {
+          label: 'octocat',
+          token: 'ghp_personal',
+        },
+      ])
+    })
+  })
+
+  test('removes the active account from the edit dialog', async () => {
+    const removed: string[] = []
+    const user = userEvent.setup()
+
+    const { getByRole } = render(
+      <AccountSwitcherView
+        accountsById={{
+          work: createAccountProfile({
+            id: 'work',
+            label: 'Work',
+            token: 'ghp_work',
+          }),
+        }}
+        activeAccountId="work"
+        addAccount={async () => {}}
+        editAccount={async () => {}}
+        removeAccount={async (accountId) => {
+          removed.push(accountId)
+          return true
+        }}
+        selectAccount={() => {}}
+      />
+    )
+
+    await user.click(getByRole('button', { name: /edit account/i }))
+    const dialog = getByRole('dialog')
+    await user.click(
+      within(dialog).getByRole('button', { name: /remove account/i })
+    )
+
+    await waitFor(() => {
+      expect(removed).toEqual(['work'])
     })
   })
 })

--- a/tests/store/accounts.test.ts
+++ b/tests/store/accounts.test.ts
@@ -4,13 +4,20 @@ import {
   createAccountProfile,
   getActiveAccount,
   getActiveWorkspace,
+  removeAccountProfile,
   selectActiveApplication,
   setActiveAccount,
   setActiveAccountApplications,
   setActiveAccountToken,
 } from '../../src/store/accounts'
-import { addAccountToState } from '../../src/store/actions'
-import { editAccountInState } from '../../src/store/actions'
+import {
+  addAccountToState,
+  editAccountInState,
+  exportApplicationsFromState,
+  importApplicationsToState,
+  removeAccountFromState,
+} from '../../src/store/actions'
+import { mergeImportedApplications } from '../../src/store/applicationImport'
 import { MIGRATED_ACCOUNT_ID } from '../../src/store/legacyMigration'
 import { parsePersistedState } from '../../src/store/persistedState'
 import { createInitialAppState } from '../../src/store/state'
@@ -275,6 +282,44 @@ describe('add account action', () => {
     })
     expect(account.workspace.applicationsById).toEqual({})
   })
+
+  test('updates an existing identity instead of creating a duplicate account', async () => {
+    const state = createInitialAppState()
+    const workApp = appConfig('work-app')
+    state.accountsById.work = createAccountProfile({
+      id: 'work',
+      label: 'Work',
+      token: 'ghp_old',
+      githubLogin: 'work-octocat',
+      githubUserId: 'U_work',
+      workspace: {
+        applicationsById: { [workApp.id]: workApp },
+        selectedApplicationId: workApp.id,
+      },
+    })
+    state.activeAccountId = 'work'
+
+    const account = await addAccountToState(
+      state,
+      {
+        label: 'Work rotated',
+        token: 'ghp_new',
+      },
+      async () => ({
+        id: 'U_work',
+        login: 'work-octocat',
+      })
+    )
+
+    expect(account.id).toBe('work')
+    expect(Object.keys(state.accountsById)).toEqual(['work'])
+    expect(state.activeAccountId).toBe('work')
+    expect(state.accountsById.work.label).toBe('Work rotated')
+    expect(state.accountsById.work.token).toBe('ghp_new')
+    expect(state.accountsById.work.workspace.applicationsById).toEqual({
+      [workApp.id]: workApp,
+    })
+  })
 })
 
 describe('account switching', () => {
@@ -471,5 +516,180 @@ describe('edit account action', () => {
     expect((error as Error).message).toContain('Add it as a new account')
     expect(state.accountsById.work.token).toBe('ghp_work')
     expect(state.accountsById.work.githubLogin).toBe('work-octocat')
+  })
+})
+
+describe('account removal', () => {
+  test('confirms removal with application count and switches away from the active account', async () => {
+    const state = createInitialAppState()
+    const workApp = appConfig('work-app')
+    state.accountsById.work = createAccountProfile({
+      id: 'work',
+      label: 'Work',
+      token: 'ghp_work',
+      githubLogin: 'work-octocat',
+      workspace: {
+        applicationsById: { [workApp.id]: workApp },
+        selectedApplicationId: workApp.id,
+      },
+    })
+    state.accountsById.personal = createAccountProfile({
+      id: 'personal',
+      label: 'Personal',
+      token: 'ghp_personal',
+    })
+    state.activeAccountId = 'work'
+    const messages: string[] = []
+
+    const removed = await removeAccountFromState(
+      state,
+      'work',
+      async (message) => {
+        messages.push(message)
+        return true
+      }
+    )
+
+    expect(removed).toBe(true)
+    expect(messages[0]).toContain('1 application')
+    expect(messages[0]).toContain('Work (@work-octocat)')
+    expect(state.accountsById.work).toBeUndefined()
+    expect(state.activeAccountId).toBe('personal')
+  })
+
+  test('keeps the account when removal is cancelled', async () => {
+    const state = createInitialAppState()
+    state.accountsById.work = createAccountProfile({
+      id: 'work',
+      label: 'Work',
+      token: 'ghp_work',
+    })
+    state.activeAccountId = 'work'
+
+    const removed = await removeAccountFromState(
+      state,
+      'work',
+      async () => false
+    )
+
+    expect(removed).toBe(false)
+    expect(state.accountsById.work).toBeTruthy()
+    expect(state.activeAccountId).toBe('work')
+  })
+
+  test('clears the active account when the final account is removed', () => {
+    const state = createInitialAppState()
+    state.accountsById.work = createAccountProfile({
+      id: 'work',
+      label: 'Work',
+      token: 'ghp_work',
+    })
+    state.activeAccountId = 'work'
+
+    removeAccountProfile(state, 'work')
+
+    expect(state.accountsById).toEqual({})
+    expect(state.activeAccountId).toBe('')
+  })
+})
+
+describe('application import and export', () => {
+  test('exports only active-account applications without account credentials', async () => {
+    const state = createInitialAppState()
+    const workApp = appConfig('work-app')
+    const personalApp = appConfig('personal-app')
+    state.accountsById.work = createAccountProfile({
+      id: 'work',
+      label: 'Work',
+      token: 'ghp_work',
+      workspace: {
+        applicationsById: { [workApp.id]: workApp },
+        selectedApplicationId: workApp.id,
+      },
+    })
+    state.accountsById.personal = createAccountProfile({
+      id: 'personal',
+      label: 'Personal',
+      token: 'ghp_personal',
+      workspace: {
+        applicationsById: { [personalApp.id]: personalApp },
+        selectedApplicationId: personalApp.id,
+      },
+    })
+    state.activeAccountId = 'personal'
+    const downloads: { obj: unknown; fileName: string }[] = []
+
+    await exportApplicationsFromState(state, (obj, fileName) => {
+      downloads.push({ obj, fileName })
+    })
+
+    expect(downloads).toEqual([
+      {
+        obj: { [personalApp.id]: personalApp },
+        fileName: 'gdc-applications.json',
+      },
+    ])
+    expect(JSON.stringify(downloads[0].obj)).not.toContain('ghp_')
+  })
+
+  test('imports applications into the active account and selects the first import when nothing is selected', async () => {
+    const state = createInitialAppState()
+    const workApp = appConfig('work-app')
+    const personalApp = appConfig('personal-app')
+    state.accountsById.work = createAccountProfile({
+      id: 'work',
+      label: 'Work',
+      token: 'ghp_work',
+      workspace: {
+        applicationsById: { [workApp.id]: workApp },
+        selectedApplicationId: workApp.id,
+      },
+    })
+    state.accountsById.personal = createAccountProfile({
+      id: 'personal',
+      label: 'Personal',
+      token: 'ghp_personal',
+    })
+    state.activeAccountId = 'personal'
+
+    await importApplicationsToState(state, async () =>
+      JSON.stringify({ [personalApp.id]: personalApp })
+    )
+
+    expect(state.accountsById.work.workspace.applicationsById).toEqual({
+      [workApp.id]: workApp,
+    })
+    expect(state.accountsById.personal.workspace.applicationsById).toEqual({
+      [personalApp.id]: personalApp,
+    })
+    expect(
+      state.accountsById.personal.workspace.selectedApplicationId
+    ).toBe(personalApp.id)
+  })
+
+  test('keeps existing applications and assigns fresh ids for import collisions', () => {
+    const existing = appConfig('shared', 'Existing')
+    const collidingImport = appConfig('shared', 'Imported')
+    const freshImport = appConfig('fresh', 'Fresh')
+    const generatedIds = ['shared', 'generated']
+
+    const result = mergeImportedApplications(
+      { [existing.id]: existing },
+      existing.id,
+      {
+        [collidingImport.id]: collidingImport,
+        [freshImport.id]: freshImport,
+      },
+      () => generatedIds.shift() ?? 'fallback'
+    )
+
+    expect(result.applicationsById.shared.name).toBe('Existing')
+    expect(result.applicationsById.generated).toEqual({
+      ...collidingImport,
+      id: 'generated',
+    })
+    expect(result.applicationsById.fresh).toEqual(freshImport)
+    expect(result.selectedApplicationId).toBe(existing.id)
+    expect(result.importedApplicationIds).toEqual(['generated', 'fresh'])
   })
 })

--- a/tests/store/accounts.test.ts
+++ b/tests/store/accounts.test.ts
@@ -667,6 +667,41 @@ describe('application import and export', () => {
     ).toBe(personalApp.id)
   })
 
+  test('ignores malformed import JSON without changing the active workspace', async () => {
+    const state = createInitialAppState()
+    const existingApp = appConfig('existing-app')
+    state.accountsById.work = createAccountProfile({
+      id: 'work',
+      label: 'Work',
+      token: 'ghp_work',
+      workspace: {
+        applicationsById: { [existingApp.id]: existingApp },
+        selectedApplicationId: existingApp.id,
+      },
+    })
+    state.activeAccountId = 'work'
+    const errors: unknown[][] = []
+    const originalConsoleError = console.error
+    console.error = (...args: unknown[]) => {
+      errors.push(args)
+    }
+
+    try {
+      await importApplicationsToState(state, async () => '{invalid json')
+    } finally {
+      console.error = originalConsoleError
+    }
+
+    expect(state.accountsById.work.workspace.applicationsById).toEqual({
+      [existingApp.id]: existingApp,
+    })
+    expect(state.accountsById.work.workspace.selectedApplicationId).toBe(
+      existingApp.id
+    )
+    expect(errors[0]?.[0]).toBe('Could not import applications JSON')
+    expect(errors[0]?.[1]).toBeInstanceOf(SyntaxError)
+  })
+
   test('keeps existing applications and assigns fresh ids for import collisions', () => {
     const existing = appConfig('shared', 'Existing')
     const collidingImport = appConfig('shared', 'Imported')


### PR DESCRIPTION
## Summary

Completes the remaining work from #15 around multi-account PAT switching and account-safe runtime behavior.

- Adds guarded account mutation behavior for duplicate GitHub identities, same-identity PAT rotation, different-identity replacement warnings, and confirmed account removal.
- Makes application import/export active-account scoped, PAT-free, additive, and collision-safe.
- Hardens GitHub-backed runtime data by using account-scoped query keys and token-bound GraphQL/REST clients for each query.
- Adds credential recovery guidance when GitHub data fetches fail because a PAT may be expired or revoked.
- Extracts GitHub runtime account-scope helpers as the final architecture pass.

## Validation

- `bun test`
- `bun run build`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Account removal from the account switcher and add-as-new-account flow for tokens with different GitHub identities
  * Improved credential error UI for token/credential failures
  * Application import/export with intelligent ID-collision merging

* **Bug Fixes**
  * Safer handling of GitHub data fetch failures and identity-related token errors

* **Refactor**
  * Centralized GitHub connectivity and consistent query-keying across fetchers

* **Tests**
  * Expanded tests covering account add/remove, identity flows, import/export, and query-key construction
<!-- end of auto-generated comment: release notes by coderabbit.ai -->