### PR TITLE
Simplify repo cache memoization

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,3 @@
+# Repository Instructions
+
+- Keep non-generated code as minimal and elegant as possible while still doing the job.

--- a/src/api/fetchHooks.ts
+++ b/src/api/fetchHooks.ts
@@ -3,7 +3,7 @@ import { useInfiniteQuery, useQuery } from '@tanstack/react-query'
 import type { UseQueryResult } from '@tanstack/react-query'
 import dayjs from 'dayjs'
 import { keyBy, orderBy } from 'lodash-es'
-import { useEffect } from 'react'
+import { useEffect, useMemo } from 'react'
 import { z } from 'zod'
 import { DeploymentState } from '../generated/graphql'
 import type { DeployFragment, RepoFragment } from '../generated/graphql'
@@ -28,7 +28,6 @@ import type {
 
 const REPO_STALE_TIME_MS = 30 * 60 * 1000
 const REPO_CACHE_MAX_AGE_MS = 7 * 24 * 60 * 60 * 1000
-const REPO_CACHE_STORAGE_PREFIX = 'gdc.v2.repos.'
 
 type RepoPage = {
   repos: RepoModel[]
@@ -44,8 +43,6 @@ const repoCacheSchema = z.object({
   nextCursor: z.string().nullable(),
   totalCount: z.number(),
 })
-
-const repoCacheByKey = new Map<string, RepoCachePage | undefined>()
 
 export const useFetchReleases = () => {
   const { activeAccountId, selectedApplication, settings, token } = useAppState()
@@ -234,9 +231,10 @@ export const useFetchRepos = ({
 }: { autoFetchAll?: boolean } = {}) => {
   const { activeAccountId, token } = useAppState()
   const scope = getGitHubQueryScope({ activeAccountId, token })
-  const cachedPage = getRepoCache(scope.repoCacheKey)
-
-  useEffect(subscribeRepoCacheStorageChanges, [])
+  const cachedPage = useMemo(
+    () => loadRepoCache(scope.repoCacheKey),
+    [scope.repoCacheKey]
+  )
 
   const query = useInfiniteQuery({
     queryKey: githubQueryKeys.repos(scope),
@@ -353,50 +351,20 @@ function buildRepoCache(pages: RepoPage[]): RepoCachePage {
   }
 }
 
-function getRepoCache(cacheKey: string): RepoCachePage | undefined {
-  if (!cacheKey) return undefined
-
-  if (repoCacheByKey.has(cacheKey)) {
-    return getUsableRepoCache(cacheKey, repoCacheByKey.get(cacheKey))
-  }
-
-  const cache = loadRepoCache(cacheKey)
-  repoCacheByKey.set(cacheKey, cache)
-  return cache
-}
-
 function loadRepoCache(cacheKey: string): RepoCachePage | undefined {
   if (!cacheKey || typeof localStorage === 'undefined') return undefined
 
   const value = localStorage.getItem(getRepoCacheStorageKey(cacheKey))
-  return parseRepoCache(value)
-}
-
-function parseRepoCache(value: string | null): RepoCachePage | undefined {
   if (!value) return undefined
 
   try {
     const cache = repoCacheSchema.parse(JSON.parse(value))
-    if (isRepoCacheExpired(cache)) return undefined
+    if (Date.now() - cache.savedAt > REPO_CACHE_MAX_AGE_MS) return undefined
     return cache
   } catch (error) {
     console.error('Could not load repository cache', error)
     return undefined
   }
-}
-
-function getUsableRepoCache(
-  cacheKey: string,
-  cache: RepoCachePage | undefined
-) {
-  if (!cache || !isRepoCacheExpired(cache)) return cache
-
-  repoCacheByKey.set(cacheKey, undefined)
-  return undefined
-}
-
-function isRepoCacheExpired(cache: RepoCachePage) {
-  return Date.now() - cache.savedAt > REPO_CACHE_MAX_AGE_MS
 }
 
 function saveRepoCache(cacheKey: string, cache: RepoCachePage) {
@@ -407,41 +375,13 @@ function saveRepoCache(cacheKey: string, cache: RepoCachePage) {
       getRepoCacheStorageKey(cacheKey),
       JSON.stringify(cache)
     )
-    repoCacheByKey.set(cacheKey, cache)
   } catch (error) {
     console.error('Could not save repository cache', error)
   }
 }
 
 function getRepoCacheStorageKey(cacheKey: string) {
-  return `${REPO_CACHE_STORAGE_PREFIX}${cacheKey}`
-}
-
-function getRepoCacheKeyFromStorageKey(storageKey: string) {
-  return storageKey.startsWith(REPO_CACHE_STORAGE_PREFIX)
-    ? storageKey.slice(REPO_CACHE_STORAGE_PREFIX.length)
-    : undefined
-}
-
-function subscribeRepoCacheStorageChanges() {
-  if (typeof window === 'undefined') return
-
-  const onStorage = (event: StorageEvent) => {
-    if (event.storageArea && event.storageArea !== localStorage) return
-
-    if (event.key === null) {
-      repoCacheByKey.clear()
-      return
-    }
-
-    const cacheKey = getRepoCacheKeyFromStorageKey(event.key)
-    if (!cacheKey) return
-
-    repoCacheByKey.set(cacheKey, parseRepoCache(event.newValue))
-  }
-
-  window.addEventListener('storage', onStorage)
-  return () => window.removeEventListener('storage', onStorage)
+  return `gdc.v2.repos.${cacheKey}`
 }
 
 function tryParseWorkflowRunId(payload: string | null): number | undefined {

--- a/src/api/fetchHooks.ts
+++ b/src/api/fetchHooks.ts
@@ -3,7 +3,7 @@ import { useInfiniteQuery, useQuery } from '@tanstack/react-query'
 import type { UseQueryResult } from '@tanstack/react-query'
 import dayjs from 'dayjs'
 import { keyBy, orderBy } from 'lodash-es'
-import { useEffect, useMemo } from 'react'
+import { useEffect } from 'react'
 import { z } from 'zod'
 import { DeploymentState } from '../generated/graphql'
 import type { DeployFragment, RepoFragment } from '../generated/graphql'
@@ -228,14 +228,8 @@ export const useFetchRepos = ({
   autoFetchAll = false,
 }: { autoFetchAll?: boolean } = {}) => {
   const { activeAccountId, token } = useAppState()
-  const scope = useMemo(
-    () => getGitHubQueryScope({ activeAccountId, token }),
-    [activeAccountId, token]
-  )
-  const cachedPage = useMemo(
-    () => loadRepoCache(scope.repoCacheKey),
-    [scope.repoCacheKey]
-  )
+  const scope = getGitHubQueryScope({ activeAccountId, token })
+  const cachedPage = loadRepoCache(scope.repoCacheKey)
 
   const query = useInfiniteQuery({
     queryKey: githubQueryKeys.repos(scope),
@@ -281,10 +275,7 @@ export const useFetchRepos = ({
     saveRepoCache(scope.repoCacheKey, buildRepoCache(query.data.pages))
   }, [query.data, scope.repoCacheKey])
 
-  const repos = useMemo(
-    () => collectRepos(query.data?.pages ?? []),
-    [query.data?.pages]
-  )
+  const repos = collectRepos(query.data?.pages ?? [])
   const lastPage = query.data?.pages.at(-1)
   const totalCount = lastPage?.totalCount
 

--- a/src/api/fetchHooks.ts
+++ b/src/api/fetchHooks.ts
@@ -28,6 +28,7 @@ import type {
 
 const REPO_STALE_TIME_MS = 30 * 60 * 1000
 const REPO_CACHE_MAX_AGE_MS = 7 * 24 * 60 * 60 * 1000
+const REPO_CACHE_STORAGE_PREFIX = 'gdc.v2.repos.'
 
 type RepoPage = {
   repos: RepoModel[]
@@ -35,12 +36,16 @@ type RepoPage = {
   totalCount: number
 }
 
+type RepoCachePage = RepoPage & { savedAt: number }
+
 const repoCacheSchema = z.object({
   savedAt: z.number(),
   repos: z.array(repoSchema),
   nextCursor: z.string().nullable(),
   totalCount: z.number(),
 })
+
+const repoCacheByKey = new Map<string, RepoCachePage | undefined>()
 
 export const useFetchReleases = () => {
   const { activeAccountId, selectedApplication, settings, token } = useAppState()
@@ -229,7 +234,9 @@ export const useFetchRepos = ({
 }: { autoFetchAll?: boolean } = {}) => {
   const { activeAccountId, token } = useAppState()
   const scope = getGitHubQueryScope({ activeAccountId, token })
-  const cachedPage = loadRepoCache(scope.repoCacheKey)
+  const cachedPage = getRepoCache(scope.repoCacheKey)
+
+  useEffect(subscribeRepoCacheStorageChanges, [])
 
   const query = useInfiniteQuery({
     queryKey: githubQueryKeys.repos(scope),
@@ -335,7 +342,7 @@ function collectRepos(pages: RepoPage[]): RepoModel[] {
   return [...reposById.values()]
 }
 
-function buildRepoCache(pages: RepoPage[]): RepoPage & { savedAt: number } {
+function buildRepoCache(pages: RepoPage[]): RepoCachePage {
   const lastPage = pages.at(-1)
 
   return {
@@ -346,17 +353,31 @@ function buildRepoCache(pages: RepoPage[]): RepoPage & { savedAt: number } {
   }
 }
 
-function loadRepoCache(
-  cacheKey: string
-): (RepoPage & { savedAt: number }) | undefined {
+function getRepoCache(cacheKey: string): RepoCachePage | undefined {
+  if (!cacheKey) return undefined
+
+  if (repoCacheByKey.has(cacheKey)) {
+    return getUsableRepoCache(cacheKey, repoCacheByKey.get(cacheKey))
+  }
+
+  const cache = loadRepoCache(cacheKey)
+  repoCacheByKey.set(cacheKey, cache)
+  return cache
+}
+
+function loadRepoCache(cacheKey: string): RepoCachePage | undefined {
   if (!cacheKey || typeof localStorage === 'undefined') return undefined
 
   const value = localStorage.getItem(getRepoCacheStorageKey(cacheKey))
+  return parseRepoCache(value)
+}
+
+function parseRepoCache(value: string | null): RepoCachePage | undefined {
   if (!value) return undefined
 
   try {
     const cache = repoCacheSchema.parse(JSON.parse(value))
-    if (Date.now() - cache.savedAt > REPO_CACHE_MAX_AGE_MS) return undefined
+    if (isRepoCacheExpired(cache)) return undefined
     return cache
   } catch (error) {
     console.error('Could not load repository cache', error)
@@ -364,10 +385,21 @@ function loadRepoCache(
   }
 }
 
-function saveRepoCache(
+function getUsableRepoCache(
   cacheKey: string,
-  cache: RepoPage & { savedAt: number }
+  cache: RepoCachePage | undefined
 ) {
+  if (!cache || !isRepoCacheExpired(cache)) return cache
+
+  repoCacheByKey.set(cacheKey, undefined)
+  return undefined
+}
+
+function isRepoCacheExpired(cache: RepoCachePage) {
+  return Date.now() - cache.savedAt > REPO_CACHE_MAX_AGE_MS
+}
+
+function saveRepoCache(cacheKey: string, cache: RepoCachePage) {
   if (typeof localStorage === 'undefined') return
 
   try {
@@ -375,13 +407,41 @@ function saveRepoCache(
       getRepoCacheStorageKey(cacheKey),
       JSON.stringify(cache)
     )
+    repoCacheByKey.set(cacheKey, cache)
   } catch (error) {
     console.error('Could not save repository cache', error)
   }
 }
 
 function getRepoCacheStorageKey(cacheKey: string) {
-  return `gdc.v2.repos.${cacheKey}`
+  return `${REPO_CACHE_STORAGE_PREFIX}${cacheKey}`
+}
+
+function getRepoCacheKeyFromStorageKey(storageKey: string) {
+  return storageKey.startsWith(REPO_CACHE_STORAGE_PREFIX)
+    ? storageKey.slice(REPO_CACHE_STORAGE_PREFIX.length)
+    : undefined
+}
+
+function subscribeRepoCacheStorageChanges() {
+  if (typeof window === 'undefined') return
+
+  const onStorage = (event: StorageEvent) => {
+    if (event.storageArea && event.storageArea !== localStorage) return
+
+    if (event.key === null) {
+      repoCacheByKey.clear()
+      return
+    }
+
+    const cacheKey = getRepoCacheKeyFromStorageKey(event.key)
+    if (!cacheKey) return
+
+    repoCacheByKey.set(cacheKey, parseRepoCache(event.newValue))
+  }
+
+  window.addEventListener('storage', onStorage)
+  return () => window.removeEventListener('storage', onStorage)
 }
 
 function tryParseWorkflowRunId(payload: string | null): number | undefined {

--- a/tests/api/fetchHooks.test.ts
+++ b/tests/api/fetchHooks.test.ts
@@ -1,16 +1,9 @@
-import '../setupDom'
-import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
-import { cleanup, render } from '@testing-library/react'
-import { afterEach, describe, expect, test } from 'bun:test'
-import React from 'react'
-import { useFetchRepos } from '../../src/api/fetchHooks'
+import { describe, expect, test } from 'bun:test'
 import {
   getGitHubQueryScope,
   githubQueryKeys,
   hashString,
 } from '../../src/api/githubRuntime'
-import { createAccountProfile } from '../../src/store/accounts'
-import { appState } from '../../src/store/state'
 import type { RepoModel } from '../../src/state/schemas'
 
 const repo: RepoModel = {
@@ -19,13 +12,6 @@ const repo: RepoModel = {
   name: 'deploy-center',
   defaultBranch: 'main',
 }
-
-afterEach(() => {
-  cleanup()
-  localStorage.clear()
-  appState.accountsById = {}
-  appState.activeAccountId = ''
-})
 
 describe('GitHub query keys', () => {
   test('scope includes active account id and a token hash, never the raw token', () => {
@@ -80,77 +66,4 @@ describe('GitHub query keys', () => {
       expect(JSON.stringify(key)).not.toContain('ghp_personal')
     }
   })
-
-  test('repository cache reads localStorage once per account token', () => {
-    const accountId = 'work'
-    const token = 'ghp_cached_repo_test'
-    const scope = getGitHubQueryScope({ activeAccountId: accountId, token })
-    const storageKey = `gdc.v2.repos.${scope.repoCacheKey}`
-    const queryClient = new QueryClient({
-      defaultOptions: { queries: { retry: false } },
-    })
-
-    localStorage.setItem(
-      storageKey,
-      JSON.stringify({
-        savedAt: Date.now(),
-        repos: [repo],
-        nextCursor: null,
-        totalCount: 1,
-      })
-    )
-    appState.accountsById = {
-      [accountId]: createAccountProfile({
-        id: accountId,
-        label: 'Work',
-        token,
-        githubLogin: 'octo',
-        githubUserId: '1',
-      }),
-    }
-    appState.activeAccountId = accountId
-
-    const originalGetItem = localStorage.getItem.bind(localStorage)
-    let getItemCalls = 0
-    Object.defineProperty(localStorage, 'getItem', {
-      configurable: true,
-      value: (key: string) => {
-        getItemCalls++
-        return originalGetItem(key)
-      },
-    })
-
-    try {
-      const renderView = (tick: number) =>
-        React.createElement(
-          QueryClientProvider,
-          { client: queryClient },
-          React.createElement(RepoCount, { tick })
-        )
-      const { getByTestId, rerender } = render(renderView(1))
-
-      expect(getByTestId('repo-count').textContent).toBe('1')
-
-      rerender(renderView(2))
-
-      expect(getByTestId('repo-count').textContent).toBe('1')
-      expect(getItemCalls).toBe(1)
-    } finally {
-      Object.defineProperty(localStorage, 'getItem', {
-        configurable: true,
-        value: originalGetItem,
-      })
-      queryClient.clear()
-    }
-  })
 })
-
-function RepoCount({ tick }: { tick: number }) {
-  const query = useFetchRepos()
-
-  return React.createElement(
-    'div',
-    { 'data-testid': 'repo-count', 'data-tick': tick },
-    query.loadedCount
-  )
-}

--- a/tests/api/fetchHooks.test.ts
+++ b/tests/api/fetchHooks.test.ts
@@ -1,9 +1,16 @@
-import { describe, expect, test } from 'bun:test'
+import '../setupDom'
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+import { cleanup, render } from '@testing-library/react'
+import { afterEach, describe, expect, test } from 'bun:test'
+import React from 'react'
+import { useFetchRepos } from '../../src/api/fetchHooks'
 import {
   getGitHubQueryScope,
   githubQueryKeys,
   hashString,
 } from '../../src/api/githubRuntime'
+import { createAccountProfile } from '../../src/store/accounts'
+import { appState } from '../../src/store/state'
 import type { RepoModel } from '../../src/state/schemas'
 
 const repo: RepoModel = {
@@ -12,6 +19,13 @@ const repo: RepoModel = {
   name: 'deploy-center',
   defaultBranch: 'main',
 }
+
+afterEach(() => {
+  cleanup()
+  localStorage.clear()
+  appState.accountsById = {}
+  appState.activeAccountId = ''
+})
 
 describe('GitHub query keys', () => {
   test('scope includes active account id and a token hash, never the raw token', () => {
@@ -66,4 +80,77 @@ describe('GitHub query keys', () => {
       expect(JSON.stringify(key)).not.toContain('ghp_personal')
     }
   })
+
+  test('repository cache reads localStorage once per account token', () => {
+    const accountId = 'work'
+    const token = 'ghp_cached_repo_test'
+    const scope = getGitHubQueryScope({ activeAccountId: accountId, token })
+    const storageKey = `gdc.v2.repos.${scope.repoCacheKey}`
+    const queryClient = new QueryClient({
+      defaultOptions: { queries: { retry: false } },
+    })
+
+    localStorage.setItem(
+      storageKey,
+      JSON.stringify({
+        savedAt: Date.now(),
+        repos: [repo],
+        nextCursor: null,
+        totalCount: 1,
+      })
+    )
+    appState.accountsById = {
+      [accountId]: createAccountProfile({
+        id: accountId,
+        label: 'Work',
+        token,
+        githubLogin: 'octo',
+        githubUserId: '1',
+      }),
+    }
+    appState.activeAccountId = accountId
+
+    const originalGetItem = localStorage.getItem.bind(localStorage)
+    let getItemCalls = 0
+    Object.defineProperty(localStorage, 'getItem', {
+      configurable: true,
+      value: (key: string) => {
+        getItemCalls++
+        return originalGetItem(key)
+      },
+    })
+
+    try {
+      const renderView = (tick: number) =>
+        React.createElement(
+          QueryClientProvider,
+          { client: queryClient },
+          React.createElement(RepoCount, { tick })
+        )
+      const { getByTestId, rerender } = render(renderView(1))
+
+      expect(getByTestId('repo-count').textContent).toBe('1')
+
+      rerender(renderView(2))
+
+      expect(getByTestId('repo-count').textContent).toBe('1')
+      expect(getItemCalls).toBe(1)
+    } finally {
+      Object.defineProperty(localStorage, 'getItem', {
+        configurable: true,
+        value: originalGetItem,
+      })
+      queryClient.clear()
+    }
+  })
 })
+
+function RepoCount({ tick }: { tick: number }) {
+  const query = useFetchRepos()
+
+  return React.createElement(
+    'div',
+    { 'data-testid': 'repo-count', 'data-tick': tick },
+    query.loadedCount
+  )
+}


### PR DESCRIPTION
## Summary
- remove redundant manual memoization around pure query-scope and repo-list derivations now that React Compiler is enabled
- keep one explicit useMemo for the localStorage-backed repository cache read, so JSON/schema parsing is tied to repoCacheKey changes instead of rerenders
- avoid the heavier module-level cache/storage-listener approach; this keeps the fix local and easier to reason about

## Verification
- bun test
- bun run build