### PR TITLE
[codex] Add application query string selection

### DIFF
--- a/src/store/applicationQueryString.ts
+++ b/src/store/applicationQueryString.ts
@@ -1,0 +1,46 @@
+import type { AppState } from './state'
+import { normalizeSelectedApplicationId } from './accounts'
+
+export const APPLICATION_QUERY_PARAM = 'application'
+
+export function getApplicationIdFromQueryString(
+  search = typeof window === 'undefined' ? '' : window.location.search
+) {
+  return new URLSearchParams(search).get(APPLICATION_QUERY_PARAM) ?? ''
+}
+
+export function selectApplicationFromQueryString(
+  state: AppState,
+  search?: string
+) {
+  const applicationId = getApplicationIdFromQueryString(search)
+  if (!applicationId) return state.selectedApplicationId
+
+  const activeAccount = state.accountsById[state.activeAccountId]
+  if (!activeAccount) return state.selectedApplicationId
+
+  activeAccount.workspace.selectedApplicationId = normalizeSelectedApplicationId(
+    activeAccount.workspace.applicationsById,
+    applicationId
+  )
+
+  return activeAccount.workspace.selectedApplicationId
+}
+
+export function replaceApplicationInQueryString(applicationId: string) {
+  if (typeof window === 'undefined') return
+
+  const url = new URL(window.location.href)
+  if (applicationId) {
+    url.searchParams.set(APPLICATION_QUERY_PARAM, applicationId)
+  } else {
+    url.searchParams.delete(APPLICATION_QUERY_PARAM)
+  }
+
+  const nextUrl = `${url.pathname}${url.search}${url.hash}`
+  const currentUrl = `${window.location.pathname}${window.location.search}${window.location.hash}`
+
+  if (nextUrl !== currentUrl) {
+    window.history.replaceState(window.history.state, '', nextUrl)
+  }
+}

--- a/src/store/persistence.ts
+++ b/src/store/persistence.ts
@@ -3,6 +3,10 @@ import { pickBy } from 'lodash-es'
 import { snapshot, subscribe } from 'valtio/vanilla'
 import type { AccountProfile, PendingDeployment } from '../state/schemas'
 import graphQLApi from '../utils/graphQLApi'
+import {
+  replaceApplicationInQueryString,
+  selectApplicationFromQueryString,
+} from './applicationQueryString'
 import { restApi } from './services'
 import { appState } from './state'
 import { parsePersistedState } from './persistedState'
@@ -23,21 +27,37 @@ export function initializeAppStore() {
     savePersistedState()
   }
 
+  syncApplicationQueryString()
+
   syncToken(appState.token)
   let lastToken = appState.token
+  let lastSelectedApplicationId = appState.selectedApplicationId
 
   subscribe(appState, () => {
     if (appState.token !== lastToken) {
       lastToken = appState.token
       syncToken(lastToken)
     }
+    if (appState.selectedApplicationId !== lastSelectedApplicationId) {
+      lastSelectedApplicationId = appState.selectedApplicationId
+      replaceApplicationInQueryString(lastSelectedApplicationId)
+    }
     savePersistedState()
   })
+
+  if (typeof window !== 'undefined') {
+    window.addEventListener('popstate', syncApplicationQueryString)
+  }
 }
 
 function syncToken(token: string) {
   graphQLApi.setToken(token)
   restApi.setToken(token)
+}
+
+function syncApplicationQueryString() {
+  selectApplicationFromQueryString(appState)
+  replaceApplicationInQueryString(appState.selectedApplicationId)
 }
 
 function applyPersistedState(state: PersistedState) {

--- a/tests/store/applicationQueryString.test.ts
+++ b/tests/store/applicationQueryString.test.ts
@@ -1,0 +1,96 @@
+import '../setupDom'
+import { afterEach, describe, expect, test } from 'bun:test'
+import {
+  getApplicationIdFromQueryString,
+  replaceApplicationInQueryString,
+  selectApplicationFromQueryString,
+} from '../../src/store/applicationQueryString'
+import { createAccountProfile } from '../../src/store/accounts'
+import { createInitialAppState } from '../../src/store/state'
+import type { ApplicationConfig } from '../../src/state/schemas'
+
+const appConfig = (id: string, name = id): ApplicationConfig => ({
+  id,
+  name,
+  releaseFilter: '',
+  repo: {
+    id: `repo-${id}`,
+    owner: 'octo',
+    name: `repo-${id}`,
+    defaultBranch: 'main',
+  },
+  deploySettings: {
+    type: 'workflow',
+    environmentKey: 'environment',
+    releaseKey: 'ref',
+    workflowId: 1,
+    ref: 'main',
+    extraArgs: {},
+  },
+  environmentSettingsByName: {},
+})
+
+afterEach(() => {
+  window.history.replaceState(null, '', '/')
+})
+
+describe('application query string selection', () => {
+  test('selects the application named in the query string', () => {
+    const firstApp = appConfig('app-1')
+    const secondApp = appConfig('app-2')
+    const state = createInitialAppState()
+    state.accountsById.work = createAccountProfile({
+      id: 'work',
+      label: 'Work',
+      token: 'ghp_work',
+      workspace: {
+        applicationsById: {
+          [firstApp.id]: firstApp,
+          [secondApp.id]: secondApp,
+        },
+        selectedApplicationId: firstApp.id,
+      },
+    })
+    state.activeAccountId = 'work'
+
+    const selectedApplicationId = selectApplicationFromQueryString(
+      state,
+      '?application=app-2'
+    )
+
+    expect(selectedApplicationId).toBe(secondApp.id)
+    expect(state.selectedApplication).toBe(secondApp)
+  })
+
+  test('does not create an account when the query string has no matching workspace', () => {
+    const state = createInitialAppState()
+
+    selectApplicationFromQueryString(state, '?application=app-2')
+
+    expect(state.accountsById).toEqual({})
+    expect(state.selectedApplicationId).toBe('')
+  })
+
+  test('reads the application query parameter', () => {
+    expect(getApplicationIdFromQueryString('?application=app-2')).toBe('app-2')
+    expect(getApplicationIdFromQueryString('?account=work')).toBe('')
+  })
+
+  test('writes the selected application without dropping other URL parts', () => {
+    window.history.replaceState(null, '', '/deploy?account=work#releases')
+
+    replaceApplicationInQueryString('app-2')
+
+    expect(window.location.pathname).toBe('/deploy')
+    expect(window.location.search).toBe('?account=work&application=app-2')
+    expect(window.location.hash).toBe('#releases')
+  })
+
+  test('removes the application query parameter when no application is selected', () => {
+    window.history.replaceState(null, '', '/deploy?application=app-2&account=work')
+
+    replaceApplicationInQueryString('')
+
+    expect(window.location.search).toBe('?account=work')
+  })
+})


### PR DESCRIPTION
## Summary
- Read the selected application from the `application` query parameter during store initialization.
- Keep the URL query string in sync when the active application changes, while preserving other query params and hash fragments.
- Add coverage for query-string selection, URL updates, and first-run safety when no account workspace exists.

Closes #12

## Validation
- `bun test`
- `bun run build`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Application selection is now synchronized with the browser URL, allowing users to share links with their selected application and navigate using the browser's back/forward buttons while maintaining their selection.

* **Tests**
  * Added comprehensive test coverage for query-string synchronization functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->